### PR TITLE
Batch create modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatsprotocol/modules-sdk",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "author": "Haberdasher Labs",
   "license": "MIT",
   "main": "dist/modules-sdk.cjs.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -20,9 +20,9 @@ import {
   ModulesRegistryFetchError,
 } from "./errors";
 import { verify } from "./schemas";
-import type { CreateInstanceResult } from "./types";
+import type { CreateInstanceResult, BatchCreateInstancesResult } from "./types";
 import { request } from "@octokit/request";
-import type { Account, Address } from "viem";
+import type { Account, Address, TransactionReceipt } from "viem";
 import type { Module, Factory, FunctionInfo } from "./types";
 
 export class HatsModulesClient {
@@ -200,7 +200,7 @@ export class HatsModulesClient {
     });
 
     const mutableArgsEncoded =
-      immutableArgs.length > 0
+      mutableArgs.length > 0
         ? encodeAbiParameters(mutableArgsTypes, mutableArgs)
         : "";
     const immutableArgsEncoded =
@@ -253,6 +253,131 @@ export class HatsModulesClient {
       console.log(err);
       throw new TransactionRevertedError("Transaction reverted");
     }
+  }
+
+  /**
+   * Batch create new module instances.
+   *
+   * @param account - A Viem account.
+   * @param moduleIds - The module IDs.
+   * @param hatIds - The hat IDs for which the modules are created.
+   * @param immutableArgsArray - Each module's immutable arguments.
+   * @param mutableArgsArray - Each module's mutable arguments.
+   * @returns An object containing the status of the call, the transaction hash and the new module instances addresses.
+   *
+   * @throws ClientNotPreparedError
+   * Thrown if the "prepare" function has not been called yet.
+   *
+   * @throws ModuleNotAvailableError
+   * Thrown if there is no module that matches the provided module ID.
+   *
+   * @throws TransactionRevertedError
+   * Thrown if the transaction reverted.
+   */
+  async batchCreateNewInstances({
+    account,
+    moduleIds,
+    hatIds,
+    immutableArgsArray,
+    mutableArgsArray,
+  }: {
+    account: Account | Address;
+    moduleIds: string[];
+    hatIds: bigint[];
+    immutableArgsArray: unknown[][];
+    mutableArgsArray: unknown[][];
+  }): Promise<BatchCreateInstancesResult> {
+    if (this._modules === undefined || this._factory === undefined) {
+      throw new ClientNotPreparedError(
+        "Client have not been initilized, requires a call to the prepare function"
+      );
+    }
+
+    const implementations: Array<string> = [];
+    const encodedImmutableArgsArray: Array<`0x${string}` | ""> = [];
+    const encodedMutableArgsArray: Array<`0x${string}` | ""> = [];
+
+    for (let i = 0; i < moduleIds.length; i++) {
+      const module = this.getModuleById(moduleIds[i]);
+      if (module === undefined) {
+        throw new ModuleNotAvailableError(
+          `Module with id ${moduleIds[i]} does not exist`
+        );
+      }
+
+      this._verifyModuleCreationArgs(
+        module,
+        hatIds[i],
+        immutableArgsArray[i],
+        mutableArgsArray[i]
+      );
+
+      const mutableArgsTypes = module.args.mutable.map((arg) => {
+        return { type: arg.type };
+      });
+      const immutableArgsTypes = module.args.immutable.map((arg) => {
+        return arg.type;
+      });
+
+      const mutableArgsEncoded =
+        mutableArgsArray[i].length > 0
+          ? encodeAbiParameters(mutableArgsTypes, mutableArgsArray[i])
+          : "";
+      const immutableArgsEncoded =
+        immutableArgsArray[i].length > 0
+          ? encodePacked(immutableArgsTypes, immutableArgsArray[i])
+          : "";
+
+      encodedMutableArgsArray.push(mutableArgsEncoded);
+      encodedImmutableArgsArray.push(immutableArgsEncoded);
+      implementations.push(module.implementationAddress);
+    }
+
+    let receipt: TransactionReceipt;
+    try {
+      const hash = await this._walletClient.writeContract({
+        address: this._factory.implementationAddress as `0x${string}`,
+        abi: this._factory.abi,
+        functionName: "batchCreateHatsModule",
+        account,
+        args: [
+          implementations as Array<`0x${string}`>,
+          hatIds,
+          encodedImmutableArgsArray,
+          encodedMutableArgsArray,
+        ],
+        chain: this._walletClient.chain,
+      });
+
+      receipt = await this._publicClient.waitForTransactionReceipt({
+        hash,
+      });
+    } catch (err) {
+      console.log(err);
+      throw new TransactionRevertedError("Transaction reverted");
+    }
+
+    const instances: Array<`0x${string}`> = [];
+    for (let eventIndex = 0; eventIndex < receipt.logs.length; eventIndex++) {
+      try {
+        const event: any = decodeEventLog({
+          abi: this._factory.abi,
+          eventName: "HatsModuleFactory_ModuleDeployed",
+          data: receipt.logs[eventIndex].data,
+          topics: receipt.logs[eventIndex].topics,
+        });
+
+        instances.push(event.args.instance);
+      } catch (err) {
+        // continue
+      }
+    }
+
+    return {
+      status: receipt.status,
+      transactionHash: receipt.transactionHash,
+      newInstances: instances,
+    };
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { HatsModulesClient } from "./client";
 import { verify, getSchema, solidityToTypescriptType } from "./schemas";
-import type { Module, Factory } from "./types";
+import type { Module, Factory, Registry } from "./types";
 
 export { HatsModulesClient, verify, getSchema, solidityToTypescriptType };
-export type { Module, Factory };
+export type { Module, Factory, Registry };

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,3 +73,10 @@ export type FunctionInfo = {
   type: "write" | "read";
   inputs: { name: string | undefined; type: string }[];
 };
+
+export type Registry = {
+  factory: Module;
+  eligibilitiesChain: Module;
+  togglesChain: Module;
+  modules: Module[];
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,10 @@ export interface CreateInstanceResult extends TransactionResult {
   newInstance: `0x${string}`;
 }
 
+export interface BatchCreateInstancesResult extends TransactionResult {
+  newInstances: Array<`0x${string}`>;
+}
+
 export type CreateInstanceArg = {
   name: string;
   description: string;

--- a/test/batchCreate.test.ts
+++ b/test/batchCreate.test.ts
@@ -6,7 +6,7 @@ import { privateKeyToAccount } from "viem/accounts";
 import * as fs from "fs";
 import type { PublicClient, WalletClient, PrivateKeyAccount } from "viem";
 import type { Anvil } from "@viem/anvil";
-import type { Module } from "../src/types";
+import type { Module, Registry } from "../src/types";
 import "dotenv/config";
 import { Abi } from "abitype";
 
@@ -57,7 +57,7 @@ describe("Batch Create Client Tests", () => {
 
     const modulesFile = new URL("modules.json", import.meta.url);
     const data = fs.readFileSync(modulesFile, "utf-8");
-    const registryModules: Module[] = JSON.parse(data);
+    const registryModules: Registry = JSON.parse(data);
 
     hatsModulesClient = new HatsModulesClient({
       publicClient,

--- a/test/batchCreate.test.ts
+++ b/test/batchCreate.test.ts
@@ -1,0 +1,423 @@
+import { HatsModulesClient, solidityToTypescriptType } from "../src/index";
+import { createPublicClient, createWalletClient, http } from "viem";
+import { goerli } from "viem/chains";
+import { createAnvil } from "@viem/anvil";
+import { privateKeyToAccount } from "viem/accounts";
+import * as fs from "fs";
+import type { PublicClient, WalletClient, PrivateKeyAccount } from "viem";
+import type { Anvil } from "@viem/anvil";
+import type { Module } from "../src/types";
+import "dotenv/config";
+import { Abi } from "abitype";
+
+describe("Batch Create Client Tests", () => {
+  let publicClient: PublicClient;
+  let walletClient: WalletClient;
+  let hatsModulesClient: HatsModulesClient;
+  let anvil: Anvil;
+  let deployerAccount: PrivateKeyAccount;
+
+  let jokeraceInstance: `0x${string}`;
+  let stakingInstance: `0x${string}`;
+  let erc20Instance: `0x${string}`;
+  let erc721Instance: `0x${string}`;
+  let erc1155Instance: `0x${string}`;
+  let claimsInstance: `0x${string}`;
+
+  let jokeraceAbi: Abi;
+  let stakingAbi: Abi;
+  let erc20Abi: Abi;
+  let erc721Abi: Abi;
+  let erc1155Abi: Abi;
+  let claimsAbi: Abi;
+
+  let immutableArgs: unknown[][];
+  let mutableArgs: unknown[][];
+
+  beforeAll(async () => {
+    anvil = createAnvil({
+      forkUrl: process.env.GOERLI_RPC,
+      startTimeout: 20000,
+    });
+    await anvil.start();
+
+    deployerAccount = privateKeyToAccount(
+      "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+    );
+
+    // init Viem clients
+    publicClient = createPublicClient({
+      chain: goerli,
+      transport: http("http://127.0.0.1:8545"),
+    });
+    walletClient = createWalletClient({
+      chain: goerli,
+      transport: http("http://127.0.0.1:8545"),
+    });
+
+    const modulesFile = new URL("modules.json", import.meta.url);
+    const data = fs.readFileSync(modulesFile, "utf-8");
+    const registryModules: Module[] = JSON.parse(data);
+
+    hatsModulesClient = new HatsModulesClient({
+      publicClient,
+      walletClient,
+      registryToken: process.env.GITHUB_TOKEN as string,
+    });
+
+    await hatsModulesClient.prepare(registryModules);
+
+    immutableArgs = [];
+    mutableArgs = [];
+
+    const jokeraceId =
+      "0xa3adb9634f813822f254bdfcecc48836b644a45f585121894409ac5eb01c67fc";
+    const stakingId =
+      "0x62c11f54dfa48ad24d8b40532ade2d3e72648e9c6c37a7a679f24268be8b155d";
+    const erc20Id =
+      "0x61ed5dcdd400854c4032ebbe1ba8a9ee43a937588ad95ccbcd4e538155fe7e3a";
+    const erc721Id =
+      "0x40a3e1da005ca0bb15c678de0508683e516f7f39e6519be6fbb01f4e6d238c91";
+    const erc1155Id =
+      "0x6ba54170154b15251037f4fdb42249717419d1845715dc3f619123fbad0d3d7e";
+    const claimsHatterId =
+      "0x65d08c510207af375cce45e411803a12a4da2c49459061d584fd5b33e9089b43";
+
+    const jokeraceModule = hatsModulesClient.getModuleById(
+      jokeraceId
+    ) as Module;
+    const stakingModule = hatsModulesClient.getModuleById(stakingId) as Module;
+    const erc20Module = hatsModulesClient.getModuleById(erc20Id) as Module;
+    const erc721Module = hatsModulesClient.getModuleById(erc721Id) as Module;
+    const erc1155Module = hatsModulesClient.getModuleById(erc1155Id) as Module;
+    const claimsHatterModule = hatsModulesClient.getModuleById(
+      claimsHatterId
+    ) as Module;
+
+    jokeraceAbi = jokeraceModule.abi;
+    stakingAbi = stakingModule.abi;
+    erc20Abi = erc20Module.abi;
+    erc721Abi = erc721Module.abi;
+    erc1155Abi = erc1155Module.abi;
+    claimsAbi = claimsHatterModule.abi;
+
+    const modules: Module[] = [
+      jokeraceModule,
+      stakingModule,
+      erc20Module,
+      erc721Module,
+      erc1155Module,
+      claimsHatterModule,
+    ];
+    const moduleIds: string[] = [
+      jokeraceId,
+      stakingId,
+      erc20Id,
+      erc721Id,
+      erc1155Id,
+      claimsHatterId,
+    ];
+    const hatIds: bigint[] = [
+      BigInt(
+        "0x0000000100000000000000000000000000000000000000000000000000000000"
+      ),
+      BigInt(
+        "0x0000000100000000000000000000000000000000000000000000000000000000"
+      ),
+      BigInt(
+        "0x0000000100000000000000000000000000000000000000000000000000000000"
+      ),
+      BigInt(
+        "0x0000000100000000000000000000000000000000000000000000000000000000"
+      ),
+      BigInt(
+        "0x0000000100000000000000000000000000000000000000000000000000000000"
+      ),
+      BigInt(
+        "0x0000000100000000000000000000000000000000000000000000000000000000"
+      ),
+    ];
+
+    for (let i = 0; i < modules.length; i++) {
+      const module = modules[i];
+      const moduleImmutableArgs: unknown[] = [];
+      const moduleMutableArgs: unknown[] = [];
+
+      for (let i = 0; i < module.args.immutable.length; i++) {
+        let arg: unknown;
+        const exampleArg = module.args.immutable[i].example;
+        const tsType = solidityToTypescriptType(module.args.immutable[i].type);
+        if (tsType === "bigint") {
+          arg = BigInt(exampleArg as string);
+        } else if (tsType === "bigint[]") {
+          arg = (exampleArg as Array<string>).map((val) => BigInt(val));
+        } else {
+          arg = exampleArg;
+        }
+
+        moduleImmutableArgs.push(arg);
+      }
+      immutableArgs.push(moduleImmutableArgs);
+
+      for (let i = 0; i < module.args.mutable.length; i++) {
+        let arg: unknown;
+        const exampleArg = module.args.mutable[i].example;
+        const tsType = solidityToTypescriptType(module.args.mutable[i].type);
+        if (tsType === "bigint") {
+          arg = BigInt(exampleArg as string);
+        } else if (tsType === "bigint[]") {
+          arg = (exampleArg as Array<string>).map((val) => BigInt(val));
+        } else {
+          arg = exampleArg;
+        }
+
+        moduleMutableArgs.push(arg);
+      }
+      mutableArgs.push(moduleMutableArgs);
+    }
+
+    const res = await hatsModulesClient.batchCreateNewInstances({
+      account: deployerAccount,
+      moduleIds,
+      hatIds,
+      immutableArgsArray: immutableArgs,
+      mutableArgsArray: mutableArgs,
+    });
+
+    jokeraceInstance = res.newInstances[0];
+    stakingInstance = res.newInstances[1];
+    erc20Instance = res.newInstances[2];
+    erc721Instance = res.newInstances[3];
+    erc1155Instance = res.newInstances[4];
+    claimsInstance = res.newInstances[5];
+  }, 35000);
+
+  afterAll(async () => {
+    await anvil.stop();
+  }, 30000);
+
+  test("Test jokerace instance", async () => {
+    const hatIdResult = await publicClient.readContract({
+      address: jokeraceInstance,
+      abi: jokeraceAbi,
+      functionName: "hatId",
+      args: [],
+    });
+
+    const adminHatResult = await publicClient.readContract({
+      address: jokeraceInstance,
+      abi: jokeraceAbi,
+      functionName: "ADMIN_HAT",
+      args: [],
+    });
+
+    const underlyingContestResult = await publicClient.readContract({
+      address: jokeraceInstance,
+      abi: jokeraceAbi,
+      functionName: "underlyingContest",
+      args: [],
+    });
+
+    const termEndResult = await publicClient.readContract({
+      address: jokeraceInstance,
+      abi: jokeraceAbi,
+      functionName: "termEnd",
+      args: [],
+    });
+
+    const topKResult = await publicClient.readContract({
+      address: jokeraceInstance,
+      abi: jokeraceAbi,
+      functionName: "topK",
+      args: [],
+    });
+
+    expect(hatIdResult).toBe(
+      BigInt(
+        "0x0000000100000000000000000000000000000000000000000000000000000000"
+      )
+    );
+    expect(adminHatResult).toBe(immutableArgs[0][0]);
+    expect(underlyingContestResult).toBe(mutableArgs[0][0]);
+    expect(termEndResult).toBe(mutableArgs[0][1]);
+    expect(topKResult).toBe(mutableArgs[0][2]);
+  });
+
+  test("Test staking instance", async () => {
+    const hatIdResult = await publicClient.readContract({
+      address: stakingInstance,
+      abi: stakingAbi,
+      functionName: "hatId",
+      args: [],
+    });
+
+    const tokenResult = await publicClient.readContract({
+      address: stakingInstance,
+      abi: stakingAbi,
+      functionName: "TOKEN",
+      args: [],
+    });
+
+    const minStakeResult = await publicClient.readContract({
+      address: stakingInstance,
+      abi: stakingAbi,
+      functionName: "minStake",
+      args: [],
+    });
+
+    const judgeHatResult = await publicClient.readContract({
+      address: stakingInstance,
+      abi: stakingAbi,
+      functionName: "judgeHat",
+      args: [],
+    });
+
+    const recipientHatResult = await publicClient.readContract({
+      address: stakingInstance,
+      abi: stakingAbi,
+      functionName: "recipientHat",
+      args: [],
+    });
+    const cooldownPeriodResult = await publicClient.readContract({
+      address: stakingInstance,
+      abi: stakingAbi,
+      functionName: "cooldownPeriod",
+      args: [],
+    });
+
+    expect(hatIdResult).toBe(
+      BigInt(
+        "0x0000000100000000000000000000000000000000000000000000000000000000"
+      )
+    );
+    expect(tokenResult).toBe(immutableArgs[1][0]);
+    expect(minStakeResult).toBe(mutableArgs[1][0]);
+    expect(judgeHatResult).toBe(mutableArgs[1][1]);
+    expect(recipientHatResult).toBe(mutableArgs[1][2]);
+    expect(cooldownPeriodResult).toBe(mutableArgs[1][3]);
+  });
+
+  test("Test erc20 instance", async () => {
+    const hatIdResult = await publicClient.readContract({
+      address: erc20Instance,
+      abi: erc20Abi,
+      functionName: "hatId",
+      args: [],
+    });
+
+    const tokenResult = await publicClient.readContract({
+      address: erc20Instance,
+      abi: erc20Abi,
+      functionName: "TOKEN_ADDRESS",
+      args: [],
+    });
+
+    const minBalanceResult = await publicClient.readContract({
+      address: erc20Instance,
+      abi: erc20Abi,
+      functionName: "MIN_BALANCE",
+      args: [],
+    });
+
+    expect(hatIdResult).toBe(
+      BigInt(
+        "0x0000000100000000000000000000000000000000000000000000000000000000"
+      )
+    );
+    expect(tokenResult).toBe(immutableArgs[2][0]);
+    expect(minBalanceResult).toBe(immutableArgs[2][1]);
+  });
+
+  test("Test erc721 instance", async () => {
+    const hatIdResult = await publicClient.readContract({
+      address: erc721Instance,
+      abi: erc721Abi,
+      functionName: "hatId",
+      args: [],
+    });
+
+    const tokenResult = await publicClient.readContract({
+      address: erc721Instance,
+      abi: erc721Abi,
+      functionName: "TOKEN_ADDRESS",
+      args: [],
+    });
+
+    const minBalanceResult = await publicClient.readContract({
+      address: erc721Instance,
+      abi: erc721Abi,
+      functionName: "MIN_BALANCE",
+      args: [],
+    });
+
+    expect(hatIdResult).toBe(
+      BigInt(
+        "0x0000000100000000000000000000000000000000000000000000000000000000"
+      )
+    );
+    expect(tokenResult).toBe(immutableArgs[3][0]);
+    expect(minBalanceResult).toBe(immutableArgs[3][1]);
+  });
+
+  test("Test erc1155 instance", async () => {
+    const hatIdResult = await publicClient.readContract({
+      address: erc1155Instance,
+      abi: erc1155Abi,
+      functionName: "hatId",
+      args: [],
+    });
+
+    const tokenResult = await publicClient.readContract({
+      address: erc1155Instance,
+      abi: erc1155Abi,
+      functionName: "TOKEN_ADDRESS",
+      args: [],
+    });
+
+    const arrayLengthResult = await publicClient.readContract({
+      address: erc1155Instance,
+      abi: erc1155Abi,
+      functionName: "ARRAY_LENGTH",
+      args: [],
+    });
+
+    const tokenIdsResult = await publicClient.readContract({
+      address: erc1155Instance,
+      abi: erc1155Abi,
+      functionName: "TOKEN_IDS",
+      args: [],
+    });
+
+    const minBalancesResult = await publicClient.readContract({
+      address: erc1155Instance,
+      abi: erc1155Abi,
+      functionName: "MIN_BALANCES",
+      args: [],
+    });
+
+    expect(hatIdResult).toBe(
+      BigInt(
+        "0x0000000100000000000000000000000000000000000000000000000000000000"
+      )
+    );
+    expect(tokenResult).toBe(immutableArgs[4][0]);
+    expect(arrayLengthResult).toBe(immutableArgs[4][1]);
+    expect(tokenIdsResult).toEqual(immutableArgs[4][2]);
+    expect(minBalancesResult).toEqual(immutableArgs[4][3]);
+  });
+
+  test("Test claims hatter instance", async () => {
+    const hatIdResult = await publicClient.readContract({
+      address: claimsInstance,
+      abi: claimsAbi,
+      functionName: "hatId",
+      args: [],
+    });
+
+    expect(hatIdResult).toBe(
+      BigInt(
+        "0x0000000100000000000000000000000000000000000000000000000000000000"
+      )
+    );
+  });
+});

--- a/test/modules.json
+++ b/test/modules.json
@@ -1,5 +1,5 @@
-[
-  {
+{
+  "factory": {
     "name": "Hats Module Factory",
     "description": "Deploys instances of hats modules.",
     "github": { "owner": "Hats-Protocol", "repo": "hats-module" },
@@ -183,225 +183,13 @@
       }
     ]
   },
-  {
-    "name": "Claims Hatter",
-    "description": "A Hats Protocol hatter contract enabling explicitly eligible wearers to claim a hat.",
-    "github": { "owner": "Hats-Protocol", "repo": "claims-hatter" },
-    "type": { "eligibility": false, "toggle": false, "hatter": true },
-    "implementationAddress": "0xd42dfDb6cf5CDe8a17E44FB9fA4480A325e9bf4a",
-    "deployments": [{ "chainId": "5", "block": "9556342" }],
-    "args": { "immutable": [], "mutable": [] },
-    "abi": [
-      {
-        "inputs": [
-          { "internalType": "string", "name": "_version", "type": "string" }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-      },
-      { "inputs": [], "name": "ClaimsHatter_NotClaimableFor", "type": "error" },
-      {
-        "inputs": [],
-        "name": "ClaimsHatter_NotExplicitlyEligible",
-        "type": "error"
-      },
-      { "inputs": [], "name": "ClaimsHatter_NotHatAdmin", "type": "error" },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "uint256",
-            "name": "_hatId",
-            "type": "uint256"
-          },
-          {
-            "indexed": false,
-            "internalType": "bool",
-            "name": "_claimableFor",
-            "type": "bool"
-          }
-        ],
-        "name": "ClaimingForChanged",
-        "type": "event"
-      },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "uint8",
-            "name": "version",
-            "type": "uint8"
-          }
-        ],
-        "name": "Initialized",
-        "type": "event"
-      },
-      {
-        "inputs": [],
-        "name": "HATS",
-        "outputs": [
-          { "internalType": "contract IHats", "name": "", "type": "address" }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "IMPLEMENTATION",
-        "outputs": [
-          { "internalType": "address", "name": "", "type": "address" }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "claimHat",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          { "internalType": "address", "name": "_wearer", "type": "address" }
-        ],
-        "name": "claimHatFor",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "claimable",
-        "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          { "internalType": "address", "name": "_wearer", "type": "address" }
-        ],
-        "name": "claimableBy",
-        "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "claimableFor",
-        "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          { "internalType": "address", "name": "_wearer", "type": "address" }
-        ],
-        "name": "claimableFor",
-        "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "disableClaimingFor",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "enableClaimingFor",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "hatExists",
-        "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "hatId",
-        "outputs": [
-          { "internalType": "uint256", "name": "", "type": "uint256" }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          { "internalType": "bytes", "name": "_initData", "type": "bytes" }
-        ],
-        "name": "setUp",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "version",
-        "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "version_",
-        "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "wearsAdmin",
-        "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-        "stateMutability": "view",
-        "type": "function"
-      }
-    ]
-  },
-  {
-    "name": "ERC1155 Eligibility",
-    "description": "An address is eligible if it holds at least one minimum balance of a set of ERC1155 token Ids",
-    "github": { "owner": "pumpedlunch", "repo": "HatsEligibilityModules" },
+  "eligibilitiesChain": {
+    "name": "Hats Eligibilities Chain",
+    "description": "Eligibility module that chains any amount of eligibility modules with 'and' & 'or' logical operations.",
+    "github": { "owner": "Hats-Protocol", "repo": "hats-module" },
     "type": { "eligibility": true, "toggle": false, "hatter": false },
-    "implementationAddress": "0x900c76737cF45a26315D5BFeBC8c383AC7192513",
-    "deployments": [{ "chainId": "5", "block": "9346764" }],
-    "args": {
-      "immutable": [
-        {
-          "name": "ERC1155 Contract Address",
-          "description": "ERC1155 contract address",
-          "type": "address",
-          "example": "0x72b51ba24452Cd5b5443B7d6725755E4d77C04e5"
-        },
-        {
-          "name": "Number Of Tokens",
-          "description": "Number of token IDs in the set of tokens that allow eligiblity",
-          "type": "uint256",
-          "example": "2"
-        },
-        {
-          "name": "Token IDs",
-          "description": "The token IDs within the ERC1155 contract that allow eligibilty",
-          "type": "uint256[]",
-          "example": ["1", "2"]
-        },
-        {
-          "name": "Minimum Balances",
-          "description": "The minimum balances required (for token ID in the corresponding index) for eligibility",
-          "type": "uint256[]",
-          "example": ["100", "500"]
-        }
-      ],
-      "mutable": []
-    },
+    "implementationAddress": "0x778b348254C556Dc3b178571B9B921fbB86e061d",
+    "deployments": [{ "chainId": "5", "block": "9635700" }],
     "abi": [
       {
         "inputs": [
@@ -410,8 +198,6 @@
         "stateMutability": "nonpayable",
         "type": "constructor"
       },
-      { "inputs": [], "name": "AlreadyInitialized", "type": "error" },
-      { "inputs": [], "name": "NotInitializing", "type": "error" },
       {
         "anonymous": false,
         "inputs": [
@@ -427,34 +213,7 @@
       },
       {
         "inputs": [],
-        "name": "ARRAY_LENGTH",
-        "outputs": [
-          { "internalType": "uint256", "name": "", "type": "uint256" }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "HATS",
-        "outputs": [
-          { "internalType": "contract IHats", "name": "", "type": "address" }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "IMPLEMENTATION",
-        "outputs": [
-          { "internalType": "address", "name": "", "type": "address" }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "MIN_BALANCES",
+        "name": "CONJUCTION_CLAUSE_LENGTHS",
         "outputs": [
           { "internalType": "uint256[]", "name": "", "type": "uint256[]" }
         ],
@@ -463,7 +222,16 @@
       },
       {
         "inputs": [],
-        "name": "TOKEN_ADDRESS",
+        "name": "HATS",
+        "outputs": [
+          { "internalType": "contract IHats", "name": "", "type": "address" }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "IMPLEMENTATION",
         "outputs": [
           { "internalType": "address", "name": "", "type": "address" }
         ],
@@ -472,7 +240,100 @@
       },
       {
         "inputs": [],
-        "name": "TOKEN_IDS",
+        "name": "MODULES",
+        "outputs": [
+          { "internalType": "address[]", "name": "", "type": "address[]" }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "NUM_CONJUCTION_CLAUSES",
+        "outputs": [
+          { "internalType": "uint256", "name": "", "type": "uint256" }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          { "internalType": "address", "name": "_wearer", "type": "address" },
+          { "internalType": "uint256", "name": "_hatId", "type": "uint256" }
+        ],
+        "name": "getWearerStatus",
+        "outputs": [
+          { "internalType": "bool", "name": "eligible", "type": "bool" },
+          { "internalType": "bool", "name": "standing", "type": "bool" }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "hatId",
+        "outputs": [
+          { "internalType": "uint256", "name": "", "type": "uint256" }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          { "internalType": "bytes", "name": "_initData", "type": "bytes" }
+        ],
+        "name": "setUp",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "version",
+        "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "version_",
+        "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+        "stateMutability": "view",
+        "type": "function"
+      }
+    ]
+  },
+  "togglesChain": {
+    "name": "Hats Toggles Chain",
+    "description": "Toggle module that chains any amount of toggle modules with 'and' & 'or' logical operations.",
+    "github": { "owner": "Hats-Protocol", "repo": "hats-module" },
+    "type": { "eligibility": false, "toggle": true, "hatter": false },
+    "implementationAddress": "0x694f7fBB438228D696CFa202B94B96C47bCBc152",
+    "deployments": [{ "chainId": "5", "block": "9635710" }],
+    "abi": [
+      {
+        "inputs": [
+          { "internalType": "string", "name": "_version", "type": "string" }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": false,
+            "internalType": "uint8",
+            "name": "version",
+            "type": "uint8"
+          }
+        ],
+        "name": "Initialized",
+        "type": "event"
+      },
+      {
+        "inputs": [],
+        "name": "CONJUCTION_CLAUSE_LENGTHS",
         "outputs": [
           { "internalType": "uint256[]", "name": "", "type": "uint256[]" }
         ],
@@ -480,100 +341,6 @@
         "type": "function"
       },
       {
-        "inputs": [
-          { "internalType": "address", "name": "_wearer", "type": "address" },
-          { "internalType": "uint256", "name": "", "type": "uint256" }
-        ],
-        "name": "getWearerStatus",
-        "outputs": [
-          { "internalType": "bool", "name": "eligible", "type": "bool" },
-          { "internalType": "bool", "name": "standing", "type": "bool" }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "hatId",
-        "outputs": [
-          { "internalType": "uint256", "name": "", "type": "uint256" }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          { "internalType": "bytes", "name": "_initData", "type": "bytes" }
-        ],
-        "name": "setUp",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "version",
-        "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "version_",
-        "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
-        "stateMutability": "view",
-        "type": "function"
-      }
-    ]
-  },
-  {
-    "name": "ERC20 Eligibility",
-    "description": "An address is eligible if it holds at least a configured minimum amount of a chosen erc20 token.",
-    "github": { "owner": "pumpedlunch", "repo": "HatsEligibilityModules" },
-    "type": { "eligibility": true, "toggle": false, "hatter": false },
-    "implementationAddress": "0x2b7eD034dCEE749FAAcEb534f917Fe290eFFD546",
-    "deployments": [{ "chainId": "5", "block": "9346755" }],
-    "args": {
-      "immutable": [
-        {
-          "name": "Token Address",
-          "description": "ERC20 token address",
-          "type": "address",
-          "example": "0x1d256A1154382921067d4B17CA52209f2d3bE106"
-        },
-        {
-          "name": "Minimum Balance",
-          "description": "Minimum amount of tokens in order to be eligible",
-          "type": "uint256",
-          "example": "500"
-        }
-      ],
-      "mutable": []
-    },
-    "abi": [
-      {
-        "inputs": [
-          { "internalType": "string", "name": "_version", "type": "string" }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-      },
-      { "inputs": [], "name": "AlreadyInitialized", "type": "error" },
-      { "inputs": [], "name": "NotInitializing", "type": "error" },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "uint8",
-            "name": "version",
-            "type": "uint8"
-          }
-        ],
-        "name": "Initialized",
-        "type": "event"
-      },
-      {
         "inputs": [],
         "name": "HATS",
         "outputs": [
@@ -593,32 +360,28 @@
       },
       {
         "inputs": [],
-        "name": "MIN_BALANCE",
+        "name": "MODULES",
         "outputs": [
-          { "internalType": "uint256", "name": "", "type": "uint256" }
+          { "internalType": "address[]", "name": "", "type": "address[]" }
         ],
         "stateMutability": "pure",
         "type": "function"
       },
       {
         "inputs": [],
-        "name": "TOKEN_ADDRESS",
+        "name": "NUM_CONJUCTION_CLAUSES",
         "outputs": [
-          { "internalType": "address", "name": "", "type": "address" }
+          { "internalType": "uint256", "name": "", "type": "uint256" }
         ],
         "stateMutability": "pure",
         "type": "function"
       },
       {
         "inputs": [
-          { "internalType": "address", "name": "_wearer", "type": "address" },
-          { "internalType": "uint256", "name": "", "type": "uint256" }
+          { "internalType": "uint256", "name": "_hatId", "type": "uint256" }
         ],
-        "name": "getWearerStatus",
-        "outputs": [
-          { "internalType": "bool", "name": "eligible", "type": "bool" },
-          { "internalType": "bool", "name": "standing", "type": "bool" }
-        ],
+        "name": "getHatStatus",
+        "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
         "stateMutability": "view",
         "type": "function"
       },
@@ -656,917 +419,1440 @@
       }
     ]
   },
-  {
-    "name": "ERC721 Eligibility",
-    "description": "An address is eligible if it holds at least a configured minimum amount of a chosen erc721 token.",
-    "github": { "owner": "pumpedlunch", "repo": "HatsEligibilityModules" },
-    "type": { "eligibility": true, "toggle": false, "hatter": false },
-    "implementationAddress": "0x6bAa65D3E024D8ebA717085691dd8A985e9F267E",
-    "deployments": [{ "chainId": "5", "block": "9346760" }],
-    "args": {
-      "immutable": [
+  "modules": [
+    {
+      "name": "Claims Hatter",
+      "description": "A Hats Protocol hatter contract enabling explicitly eligible wearers to claim a hat.",
+      "github": { "owner": "Hats-Protocol", "repo": "claims-hatter" },
+      "type": { "eligibility": false, "toggle": false, "hatter": true },
+      "implementationAddress": "0xd42dfDb6cf5CDe8a17E44FB9fA4480A325e9bf4a",
+      "deployments": [{ "chainId": "5", "block": "9556342" }],
+      "args": { "immutable": [], "mutable": [] },
+      "abi": [
         {
-          "name": "Token Address",
-          "description": "ERC721 token address",
-          "type": "address",
-          "example": "0x72b51ba24452Cd5b5443B7d6725755E4d77C04e5"
+          "inputs": [
+            { "internalType": "string", "name": "_version", "type": "string" }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "constructor"
         },
         {
-          "name": "Minimum Balance",
-          "description": "Minimum amount of tokens in order to be eligible",
-          "type": "uint256",
-          "example": "500"
-        }
-      ],
-      "mutable": []
-    },
-    "abi": [
-      {
-        "inputs": [
-          { "internalType": "string", "name": "_version", "type": "string" }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-      },
-      { "inputs": [], "name": "AlreadyInitialized", "type": "error" },
-      { "inputs": [], "name": "NotInitializing", "type": "error" },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "uint8",
-            "name": "version",
-            "type": "uint8"
-          }
-        ],
-        "name": "Initialized",
-        "type": "event"
-      },
-      {
-        "inputs": [],
-        "name": "HATS",
-        "outputs": [
-          { "internalType": "contract IHats", "name": "", "type": "address" }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "IMPLEMENTATION",
-        "outputs": [
-          { "internalType": "address", "name": "", "type": "address" }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "MIN_BALANCE",
-        "outputs": [
-          { "internalType": "uint256", "name": "", "type": "uint256" }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "TOKEN_ADDRESS",
-        "outputs": [
-          { "internalType": "address", "name": "", "type": "address" }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          { "internalType": "address", "name": "_wearer", "type": "address" },
-          { "internalType": "uint256", "name": "", "type": "uint256" }
-        ],
-        "name": "getWearerStatus",
-        "outputs": [
-          { "internalType": "bool", "name": "eligible", "type": "bool" },
-          { "internalType": "bool", "name": "standing", "type": "bool" }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "hatId",
-        "outputs": [
-          { "internalType": "uint256", "name": "", "type": "uint256" }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          { "internalType": "bytes", "name": "_initData", "type": "bytes" }
-        ],
-        "name": "setUp",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "version",
-        "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "version_",
-        "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
-        "stateMutability": "view",
-        "type": "function"
-      }
-    ]
-  },
-  {
-    "name": "JokeRace Eligibility",
-    "description": "Defines eligibility for wearers according to a Jokerace contest results.",
-    "github": { "owner": "Hats-Protocol", "repo": "jokerace-eligibility" },
-    "type": { "eligibility": true, "toggle": false, "hatter": false },
-    "implementationAddress": "0xd7c10b09453007993960FE2f92cE497A32059E08",
-    "deployments": [{ "chainId": "5", "block": "9412522" }],
-    "args": {
-      "immutable": [
-        {
-          "name": "Admin Hat",
-          "description": "Optional admin hat, granted a permission to create a new term (reelection). If not provided (equals zero), then this permission is granted to the admins of the hat",
-          "type": "uint256",
-          "example": "26959946667150639794667015087019630673637144422540572481103610249216"
-        }
-      ],
-      "mutable": [
-        {
-          "name": "JokeRace Contest",
-          "description": "The JokeRace constest that facilitates the election",
-          "type": "address",
-          "example": "0xd00F6a711522a84C73aED9997Fcf207B41E97311"
+          "inputs": [],
+          "name": "ClaimsHatter_NotClaimableFor",
+          "type": "error"
         },
         {
-          "name": "Term End",
-          "description": "Timestamp of the term ending (in seconds)",
-          "type": "uint256",
-          "example": "1723155807"
+          "inputs": [],
+          "name": "ClaimsHatter_NotExplicitlyEligible",
+          "type": "error"
+        },
+        { "inputs": [], "name": "ClaimsHatter_NotHatAdmin", "type": "error" },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": false,
+              "internalType": "uint256",
+              "name": "_hatId",
+              "type": "uint256"
+            },
+            {
+              "indexed": false,
+              "internalType": "bool",
+              "name": "_claimableFor",
+              "type": "bool"
+            }
+          ],
+          "name": "ClaimingForChanged",
+          "type": "event"
         },
         {
-          "name": "Top K",
-          "description": "First K winners of the election will be eligible",
-          "type": "uint256",
-          "example": "3"
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": false,
+              "internalType": "uint8",
+              "name": "version",
+              "type": "uint8"
+            }
+          ],
+          "name": "Initialized",
+          "type": "event"
+        },
+        {
+          "inputs": [],
+          "name": "HATS",
+          "outputs": [
+            { "internalType": "contract IHats", "name": "", "type": "address" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "IMPLEMENTATION",
+          "outputs": [
+            { "internalType": "address", "name": "", "type": "address" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "claimHat",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "address", "name": "_wearer", "type": "address" }
+          ],
+          "name": "claimHatFor",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "claimable",
+          "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "address", "name": "_wearer", "type": "address" }
+          ],
+          "name": "claimableBy",
+          "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "claimableFor",
+          "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "address", "name": "_wearer", "type": "address" }
+          ],
+          "name": "claimableFor",
+          "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "disableClaimingFor",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "enableClaimingFor",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "hatExists",
+          "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "hatId",
+          "outputs": [
+            { "internalType": "uint256", "name": "", "type": "uint256" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "bytes", "name": "_initData", "type": "bytes" }
+          ],
+          "name": "setUp",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "version",
+          "outputs": [
+            { "internalType": "string", "name": "", "type": "string" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "version_",
+          "outputs": [
+            { "internalType": "string", "name": "", "type": "string" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "wearsAdmin",
+          "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+          "stateMutability": "view",
+          "type": "function"
         }
       ]
     },
-    "abi": [
-      {
-        "inputs": [
-          { "internalType": "string", "name": "_version", "type": "string" }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-      },
-      {
-        "inputs": [],
-        "name": "JokeraceEligibility_ContestNotCompleted",
-        "type": "error"
-      },
-      { "inputs": [], "name": "JokeraceEligibility_NoTies", "type": "error" },
-      { "inputs": [], "name": "JokeraceEligibility_NotAdmin", "type": "error" },
-      {
-        "inputs": [],
-        "name": "JokeraceEligibility_TermNotCompleted",
-        "type": "error"
-      },
-      {
-        "anonymous": false,
-        "inputs": [
+    {
+      "name": "ERC1155 Eligibility",
+      "description": "An address is eligible if it holds at least one minimum balance of a set of ERC1155 token Ids",
+      "github": { "owner": "pumpedlunch", "repo": "HatsEligibilityModules" },
+      "type": { "eligibility": true, "toggle": false, "hatter": false },
+      "implementationAddress": "0x900c76737cF45a26315D5BFeBC8c383AC7192513",
+      "deployments": [{ "chainId": "5", "block": "9346764" }],
+      "args": {
+        "immutable": [
           {
-            "indexed": false,
-            "internalType": "uint8",
-            "name": "version",
-            "type": "uint8"
+            "name": "ERC1155 Contract Address",
+            "description": "ERC1155 contract address",
+            "type": "address",
+            "example": "0x72b51ba24452Cd5b5443B7d6725755E4d77C04e5"
+          },
+          {
+            "name": "Number Of Tokens",
+            "description": "Number of token IDs in the set of tokens that allow eligiblity",
+            "type": "uint256",
+            "example": "2"
+          },
+          {
+            "name": "Token IDs",
+            "description": "The token IDs within the ERC1155 contract that allow eligibilty",
+            "type": "uint256[]",
+            "example": ["1", "2"]
+          },
+          {
+            "name": "Minimum Balances",
+            "description": "The minimum balances required (for token ID in the corresponding index) for eligibility",
+            "type": "uint256[]",
+            "example": ["100", "500"]
           }
         ],
-        "name": "Initialized",
-        "type": "event"
+        "mutable": []
       },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "address",
-            "name": "NewContest",
-            "type": "address"
-          },
-          {
-            "indexed": false,
-            "internalType": "uint256",
-            "name": "newTopK",
-            "type": "uint256"
-          },
-          {
-            "indexed": false,
-            "internalType": "uint256",
-            "name": "newTermEnd",
-            "type": "uint256"
-          }
-        ],
-        "name": "NewTerm",
-        "type": "event"
-      },
-      {
-        "inputs": [],
-        "name": "ADMIN_HAT",
-        "outputs": [
-          { "internalType": "uint256", "name": "", "type": "uint256" }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "HATS",
-        "outputs": [
-          { "internalType": "contract IHats", "name": "", "type": "address" }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "IMPLEMENTATION",
-        "outputs": [
-          { "internalType": "address", "name": "", "type": "address" }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          { "internalType": "address", "name": "wearer", "type": "address" },
-          { "internalType": "address", "name": "contest", "type": "address" }
-        ],
-        "name": "eligibleWearersPerContest",
-        "outputs": [
-          { "internalType": "bool", "name": "eligible", "type": "bool" }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          { "internalType": "address", "name": "_wearer", "type": "address" },
-          { "internalType": "uint256", "name": "", "type": "uint256" }
-        ],
-        "name": "getWearerStatus",
-        "outputs": [
-          { "internalType": "bool", "name": "eligible", "type": "bool" },
-          { "internalType": "bool", "name": "standing", "type": "bool" }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "hatId",
-        "outputs": [
-          { "internalType": "uint256", "name": "", "type": "uint256" }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "pullElectionResults",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "address",
-            "name": "newUnderlyingContest",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "newTermEnd",
-            "type": "uint256"
-          },
-          { "internalType": "uint256", "name": "newTopK", "type": "uint256" }
-        ],
-        "name": "reelection",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "reelectionAllowed",
-        "outputs": [
-          { "internalType": "bool", "name": "allowed", "type": "bool" }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          { "internalType": "bytes", "name": "_initData", "type": "bytes" }
-        ],
-        "name": "setUp",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "termEnd",
-        "outputs": [
-          { "internalType": "uint256", "name": "", "type": "uint256" }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "topK",
-        "outputs": [
-          { "internalType": "uint256", "name": "", "type": "uint256" }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "underlyingContest",
-        "outputs": [
-          { "internalType": "address", "name": "", "type": "address" }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "version",
-        "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "version_",
-        "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
-        "stateMutability": "view",
-        "type": "function"
-      }
-    ]
-  },
-  {
-    "name": "Staking Eligibility",
-    "description": "Requires wearers of a given Hat to stake a minimum amount of a specified token in order to be eligible, and enables others in the hat tree's organization to slash the stake of a wearer who is behaving badly.",
-    "github": { "owner": "Hats-Protocol", "repo": "staking-eligibility" },
-    "type": { "eligibility": true, "toggle": false, "hatter": false },
-    "implementationAddress": "0x04c8851CDd118b643e38eF32AFD8B76B5197743e",
-    "deployments": [{ "chainId": "5", "block": "9406370" }],
-    "args": {
-      "immutable": [
+      "abi": [
         {
-          "name": "Staking Token",
-          "description": "ERC-20 Token which will be used for staking",
-          "type": "address",
-          "example": "0x1d256A1154382921067d4B17CA52209f2d3bE106"
-        }
-      ],
-      "mutable": [
+          "inputs": [
+            { "internalType": "string", "name": "_version", "type": "string" }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "constructor"
+        },
+        { "inputs": [], "name": "AlreadyInitialized", "type": "error" },
+        { "inputs": [], "name": "NotInitializing", "type": "error" },
         {
-          "name": "Minimum Stake",
-          "description": "The minimum stake required to be eligible for the hat",
-          "type": "uint256",
-          "example": "100"
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": false,
+              "internalType": "uint8",
+              "name": "version",
+              "type": "uint8"
+            }
+          ],
+          "name": "Initialized",
+          "type": "event"
         },
         {
-          "name": "Judge Hat",
-          "description": "The hat that can slash wearers",
-          "type": "uint256",
-          "example": "26959946667150639794667015087019630673637144422540572481103610249216"
+          "inputs": [],
+          "name": "ARRAY_LENGTH",
+          "outputs": [
+            { "internalType": "uint256", "name": "", "type": "uint256" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
         },
         {
-          "name": "Recipient Hat",
-          "description": "The hat that can withdraw slashed stakes",
-          "type": "uint256",
-          "example": "53919893334301279589334030174039261347274288845081144962207220498432"
+          "inputs": [],
+          "name": "HATS",
+          "outputs": [
+            { "internalType": "contract IHats", "name": "", "type": "address" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
         },
         {
-          "name": "Cooldown Period",
-          "description": "The number of seconds that must elapse between beginning an unstake and completing it. This should be set long enough to give a wearer of the judge hat enough time to slash a misbehaving staker before they can unstake",
-          "type": "uint256",
-          "example": "86400"
+          "inputs": [],
+          "name": "IMPLEMENTATION",
+          "outputs": [
+            { "internalType": "address", "name": "", "type": "address" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "MIN_BALANCES",
+          "outputs": [
+            { "internalType": "uint256[]", "name": "", "type": "uint256[]" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "TOKEN_ADDRESS",
+          "outputs": [
+            { "internalType": "address", "name": "", "type": "address" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "TOKEN_IDS",
+          "outputs": [
+            { "internalType": "uint256[]", "name": "", "type": "uint256[]" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "address", "name": "_wearer", "type": "address" },
+            { "internalType": "uint256", "name": "", "type": "uint256" }
+          ],
+          "name": "getWearerStatus",
+          "outputs": [
+            { "internalType": "bool", "name": "eligible", "type": "bool" },
+            { "internalType": "bool", "name": "standing", "type": "bool" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "hatId",
+          "outputs": [
+            { "internalType": "uint256", "name": "", "type": "uint256" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "bytes", "name": "_initData", "type": "bytes" }
+          ],
+          "name": "setUp",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "version",
+          "outputs": [
+            { "internalType": "string", "name": "", "type": "string" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "version_",
+          "outputs": [
+            { "internalType": "string", "name": "", "type": "string" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
         }
       ]
     },
-    "abi": [
-      {
-        "inputs": [
-          { "internalType": "string", "name": "_version", "type": "string" }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-      },
-      {
-        "inputs": [],
-        "name": "StakingEligibility_AlreadySlashed",
-        "type": "error"
-      },
-      {
-        "inputs": [],
-        "name": "StakingEligibility_CooldownNotEnded",
-        "type": "error"
-      },
-      {
-        "inputs": [],
-        "name": "StakingEligibility_HatImmutable",
-        "type": "error"
-      },
-      {
-        "inputs": [],
-        "name": "StakingEligibility_InsufficientStake",
-        "type": "error"
-      },
-      {
-        "inputs": [],
-        "name": "StakingEligibility_NoCooldown",
-        "type": "error"
-      },
-      {
-        "inputs": [],
-        "name": "StakingEligibility_NotHatAdmin",
-        "type": "error"
-      },
-      { "inputs": [], "name": "StakingEligibility_NotJudge", "type": "error" },
-      {
-        "inputs": [],
-        "name": "StakingEligibility_NotRecipient",
-        "type": "error"
-      },
-      {
-        "inputs": [],
-        "name": "StakingEligibility_NotSlashed",
-        "type": "error"
-      },
-      {
-        "inputs": [],
-        "name": "StakingEligibility_NothingToWithdraw",
-        "type": "error"
-      },
-      {
-        "inputs": [],
-        "name": "StakingEligibility_TransferFailed",
-        "type": "error"
-      },
-      {
-        "anonymous": false,
-        "inputs": [
+    {
+      "name": "ERC20 Eligibility",
+      "description": "An address is eligible if it holds at least a configured minimum amount of a chosen erc20 token.",
+      "github": { "owner": "pumpedlunch", "repo": "HatsEligibilityModules" },
+      "type": { "eligibility": true, "toggle": false, "hatter": false },
+      "implementationAddress": "0x2b7eD034dCEE749FAAcEb534f917Fe290eFFD546",
+      "deployments": [{ "chainId": "5", "block": "9346755" }],
+      "args": {
+        "immutable": [
           {
-            "indexed": false,
-            "internalType": "uint8",
-            "name": "version",
-            "type": "uint8"
-          }
-        ],
-        "name": "Initialized",
-        "type": "event"
-      },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "uint256",
-            "name": "newDelay",
-            "type": "uint256"
-          }
-        ],
-        "name": "StakingEligibility_CooldownPeriodChanged",
-        "type": "event"
-      },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "uint256",
-            "name": "hatId",
-            "type": "uint256"
+            "name": "Token Address",
+            "description": "ERC20 token address",
+            "type": "address",
+            "example": "0x1d256A1154382921067d4B17CA52209f2d3bE106"
           },
           {
-            "indexed": false,
-            "internalType": "address",
-            "name": "instance",
-            "type": "address"
+            "name": "Minimum Balance",
+            "description": "Minimum amount of tokens in order to be eligible",
+            "type": "uint256",
+            "example": "500"
+          }
+        ],
+        "mutable": []
+      },
+      "abi": [
+        {
+          "inputs": [
+            { "internalType": "string", "name": "_version", "type": "string" }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "constructor"
+        },
+        { "inputs": [], "name": "AlreadyInitialized", "type": "error" },
+        { "inputs": [], "name": "NotInitializing", "type": "error" },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": false,
+              "internalType": "uint8",
+              "name": "version",
+              "type": "uint8"
+            }
+          ],
+          "name": "Initialized",
+          "type": "event"
+        },
+        {
+          "inputs": [],
+          "name": "HATS",
+          "outputs": [
+            { "internalType": "contract IHats", "name": "", "type": "address" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "IMPLEMENTATION",
+          "outputs": [
+            { "internalType": "address", "name": "", "type": "address" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "MIN_BALANCE",
+          "outputs": [
+            { "internalType": "uint256", "name": "", "type": "uint256" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "TOKEN_ADDRESS",
+          "outputs": [
+            { "internalType": "address", "name": "", "type": "address" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "address", "name": "_wearer", "type": "address" },
+            { "internalType": "uint256", "name": "", "type": "uint256" }
+          ],
+          "name": "getWearerStatus",
+          "outputs": [
+            { "internalType": "bool", "name": "eligible", "type": "bool" },
+            { "internalType": "bool", "name": "standing", "type": "bool" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "hatId",
+          "outputs": [
+            { "internalType": "uint256", "name": "", "type": "uint256" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "bytes", "name": "_initData", "type": "bytes" }
+          ],
+          "name": "setUp",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "version",
+          "outputs": [
+            { "internalType": "string", "name": "", "type": "string" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "version_",
+          "outputs": [
+            { "internalType": "string", "name": "", "type": "string" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        }
+      ]
+    },
+    {
+      "name": "ERC721 Eligibility",
+      "description": "An address is eligible if it holds at least a configured minimum amount of a chosen erc721 token.",
+      "github": { "owner": "pumpedlunch", "repo": "HatsEligibilityModules" },
+      "type": { "eligibility": true, "toggle": false, "hatter": false },
+      "implementationAddress": "0x6bAa65D3E024D8ebA717085691dd8A985e9F267E",
+      "deployments": [{ "chainId": "5", "block": "9346760" }],
+      "args": {
+        "immutable": [
+          {
+            "name": "Token Address",
+            "description": "ERC721 token address",
+            "type": "address",
+            "example": "0x72b51ba24452Cd5b5443B7d6725755E4d77C04e5"
           },
           {
-            "indexed": false,
-            "internalType": "address",
-            "name": "token",
-            "type": "address"
+            "name": "Minimum Balance",
+            "description": "Minimum amount of tokens in order to be eligible",
+            "type": "uint256",
+            "example": "500"
+          }
+        ],
+        "mutable": []
+      },
+      "abi": [
+        {
+          "inputs": [
+            { "internalType": "string", "name": "_version", "type": "string" }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "constructor"
+        },
+        { "inputs": [], "name": "AlreadyInitialized", "type": "error" },
+        { "inputs": [], "name": "NotInitializing", "type": "error" },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": false,
+              "internalType": "uint8",
+              "name": "version",
+              "type": "uint8"
+            }
+          ],
+          "name": "Initialized",
+          "type": "event"
+        },
+        {
+          "inputs": [],
+          "name": "HATS",
+          "outputs": [
+            { "internalType": "contract IHats", "name": "", "type": "address" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "IMPLEMENTATION",
+          "outputs": [
+            { "internalType": "address", "name": "", "type": "address" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "MIN_BALANCE",
+          "outputs": [
+            { "internalType": "uint256", "name": "", "type": "uint256" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "TOKEN_ADDRESS",
+          "outputs": [
+            { "internalType": "address", "name": "", "type": "address" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "address", "name": "_wearer", "type": "address" },
+            { "internalType": "uint256", "name": "", "type": "uint256" }
+          ],
+          "name": "getWearerStatus",
+          "outputs": [
+            { "internalType": "bool", "name": "eligible", "type": "bool" },
+            { "internalType": "bool", "name": "standing", "type": "bool" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "hatId",
+          "outputs": [
+            { "internalType": "uint256", "name": "", "type": "uint256" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "bytes", "name": "_initData", "type": "bytes" }
+          ],
+          "name": "setUp",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "version",
+          "outputs": [
+            { "internalType": "string", "name": "", "type": "string" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "version_",
+          "outputs": [
+            { "internalType": "string", "name": "", "type": "string" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        }
+      ]
+    },
+    {
+      "name": "JokeRace Eligibility",
+      "description": "Defines eligibility for wearers according to a Jokerace contest results.",
+      "github": { "owner": "Hats-Protocol", "repo": "jokerace-eligibility" },
+      "type": { "eligibility": true, "toggle": false, "hatter": false },
+      "implementationAddress": "0xd7c10b09453007993960FE2f92cE497A32059E08",
+      "deployments": [{ "chainId": "5", "block": "9412522" }],
+      "args": {
+        "immutable": [
+          {
+            "name": "Admin Hat",
+            "description": "Optional admin hat, granted a permission to create a new term (reelection). If not provided (equals zero), then this permission is granted to the admins of the hat",
+            "type": "uint256",
+            "example": "26959946667150639794667015087019630673637144422540572481103610249216"
+          }
+        ],
+        "mutable": [
+          {
+            "name": "JokeRace Contest",
+            "description": "The JokeRace constest that facilitates the election",
+            "type": "address",
+            "example": "0xd00F6a711522a84C73aED9997Fcf207B41E97311"
           },
           {
-            "indexed": false,
-            "internalType": "uint248",
-            "name": "minStake",
-            "type": "uint248"
+            "name": "Term End",
+            "description": "Timestamp of the term ending (in seconds)",
+            "type": "uint256",
+            "example": "1723155807"
           },
           {
-            "indexed": false,
-            "internalType": "uint256",
-            "name": "judgeHat",
-            "type": "uint256"
+            "name": "Top K",
+            "description": "First K winners of the election will be eligible",
+            "type": "uint256",
+            "example": "3"
+          }
+        ]
+      },
+      "abi": [
+        {
+          "inputs": [
+            { "internalType": "string", "name": "_version", "type": "string" }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "constructor"
+        },
+        {
+          "inputs": [],
+          "name": "JokeraceEligibility_ContestNotCompleted",
+          "type": "error"
+        },
+        { "inputs": [], "name": "JokeraceEligibility_NoTies", "type": "error" },
+        {
+          "inputs": [],
+          "name": "JokeraceEligibility_NotAdmin",
+          "type": "error"
+        },
+        {
+          "inputs": [],
+          "name": "JokeraceEligibility_TermNotCompleted",
+          "type": "error"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": false,
+              "internalType": "uint8",
+              "name": "version",
+              "type": "uint8"
+            }
+          ],
+          "name": "Initialized",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": false,
+              "internalType": "address",
+              "name": "NewContest",
+              "type": "address"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint256",
+              "name": "newTopK",
+              "type": "uint256"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint256",
+              "name": "newTermEnd",
+              "type": "uint256"
+            }
+          ],
+          "name": "NewTerm",
+          "type": "event"
+        },
+        {
+          "inputs": [],
+          "name": "ADMIN_HAT",
+          "outputs": [
+            { "internalType": "uint256", "name": "", "type": "uint256" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "HATS",
+          "outputs": [
+            { "internalType": "contract IHats", "name": "", "type": "address" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "IMPLEMENTATION",
+          "outputs": [
+            { "internalType": "address", "name": "", "type": "address" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "address", "name": "wearer", "type": "address" },
+            { "internalType": "address", "name": "contest", "type": "address" }
+          ],
+          "name": "eligibleWearersPerContest",
+          "outputs": [
+            { "internalType": "bool", "name": "eligible", "type": "bool" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "address", "name": "_wearer", "type": "address" },
+            { "internalType": "uint256", "name": "", "type": "uint256" }
+          ],
+          "name": "getWearerStatus",
+          "outputs": [
+            { "internalType": "bool", "name": "eligible", "type": "bool" },
+            { "internalType": "bool", "name": "standing", "type": "bool" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "hatId",
+          "outputs": [
+            { "internalType": "uint256", "name": "", "type": "uint256" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "pullElectionResults",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "newUnderlyingContest",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "newTermEnd",
+              "type": "uint256"
+            },
+            { "internalType": "uint256", "name": "newTopK", "type": "uint256" }
+          ],
+          "name": "reelection",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "reelectionAllowed",
+          "outputs": [
+            { "internalType": "bool", "name": "allowed", "type": "bool" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "bytes", "name": "_initData", "type": "bytes" }
+          ],
+          "name": "setUp",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "termEnd",
+          "outputs": [
+            { "internalType": "uint256", "name": "", "type": "uint256" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "topK",
+          "outputs": [
+            { "internalType": "uint256", "name": "", "type": "uint256" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "underlyingContest",
+          "outputs": [
+            { "internalType": "address", "name": "", "type": "address" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "version",
+          "outputs": [
+            { "internalType": "string", "name": "", "type": "string" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "version_",
+          "outputs": [
+            { "internalType": "string", "name": "", "type": "string" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        }
+      ]
+    },
+    {
+      "name": "Staking Eligibility",
+      "description": "Requires wearers of a given Hat to stake a minimum amount of a specified token in order to be eligible, and enables others in the hat tree's organization to slash the stake of a wearer who is behaving badly.",
+      "github": { "owner": "Hats-Protocol", "repo": "staking-eligibility" },
+      "type": { "eligibility": true, "toggle": false, "hatter": false },
+      "implementationAddress": "0x04c8851CDd118b643e38eF32AFD8B76B5197743e",
+      "deployments": [{ "chainId": "5", "block": "9406370" }],
+      "args": {
+        "immutable": [
+          {
+            "name": "Staking Token",
+            "description": "ERC-20 Token which will be used for staking",
+            "type": "address",
+            "example": "0x1d256A1154382921067d4B17CA52209f2d3bE106"
+          }
+        ],
+        "mutable": [
+          {
+            "name": "Minimum Stake",
+            "description": "The minimum stake required to be eligible for the hat",
+            "type": "uint256",
+            "example": "100"
           },
           {
-            "indexed": false,
-            "internalType": "uint256",
-            "name": "recipientHat",
-            "type": "uint256"
+            "name": "Judge Hat",
+            "description": "The hat that can slash wearers",
+            "type": "uint256",
+            "example": "26959946667150639794667015087019630673637144422540572481103610249216"
           },
           {
-            "indexed": false,
-            "internalType": "uint256",
-            "name": "cooldownPeriod",
-            "type": "uint256"
-          }
-        ],
-        "name": "StakingEligibility_Deployed",
-        "type": "event"
-      },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "address",
-            "name": "staker",
-            "type": "address"
-          }
-        ],
-        "name": "StakingEligibility_Forgiven",
-        "type": "event"
-      },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "uint256",
-            "name": "newJudgeHat",
-            "type": "uint256"
-          }
-        ],
-        "name": "StakingEligibility_JudgeHatChanged",
-        "type": "event"
-      },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "uint248",
-            "name": "newMinStake",
-            "type": "uint248"
-          }
-        ],
-        "name": "StakingEligibility_MinStakeChanged",
-        "type": "event"
-      },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "uint256",
-            "name": "newRecipientHat",
-            "type": "uint256"
-          }
-        ],
-        "name": "StakingEligibility_RecipientHatChanged",
-        "type": "event"
-      },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "address",
-            "name": "wearer",
-            "type": "address"
+            "name": "Recipient Hat",
+            "description": "The hat that can withdraw slashed stakes",
+            "type": "uint256",
+            "example": "53919893334301279589334030174039261347274288845081144962207220498432"
           },
           {
-            "indexed": false,
-            "internalType": "uint248",
-            "name": "amount",
-            "type": "uint248"
+            "name": "Cooldown Period",
+            "description": "The number of seconds that must elapse between beginning an unstake and completing it. This should be set long enough to give a wearer of the judge hat enough time to slash a misbehaving staker before they can unstake",
+            "type": "uint256",
+            "example": "86400"
           }
-        ],
-        "name": "StakingEligibility_Slashed",
-        "type": "event"
+        ]
       },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "address",
-            "name": "staker",
-            "type": "address"
-          },
-          {
-            "indexed": false,
-            "internalType": "uint248",
-            "name": "amount",
-            "type": "uint248"
-          }
-        ],
-        "name": "StakingEligibility_Staked",
-        "type": "event"
-      },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "address",
-            "name": "staker",
-            "type": "address"
-          },
-          {
-            "indexed": false,
-            "internalType": "uint248",
-            "name": "amount",
-            "type": "uint248"
-          },
-          {
-            "indexed": false,
-            "internalType": "uint256",
-            "name": "cooldownEnd",
-            "type": "uint256"
-          }
-        ],
-        "name": "StakingEligibility_UnstakeBegun",
-        "type": "event"
-      },
-      {
-        "inputs": [],
-        "name": "HATS",
-        "outputs": [
-          { "internalType": "contract IHats", "name": "", "type": "address" }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "IMPLEMENTATION",
-        "outputs": [
-          { "internalType": "address", "name": "", "type": "address" }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "TOKEN",
-        "outputs": [
-          { "internalType": "contract IERC20", "name": "", "type": "address" }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          { "internalType": "uint248", "name": "_amount", "type": "uint248" }
-        ],
-        "name": "beginUnstake",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "uint256",
-            "name": "_cooldownPeriod",
-            "type": "uint256"
-          }
-        ],
-        "name": "changeCooldownPeriod",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          { "internalType": "uint256", "name": "_judgeHat", "type": "uint256" }
-        ],
-        "name": "changeJudgeHat",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          { "internalType": "uint248", "name": "_minStake", "type": "uint248" }
-        ],
-        "name": "changeMinStake",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "uint256",
-            "name": "_recipientHat",
-            "type": "uint256"
-          }
-        ],
-        "name": "changeRecipientHat",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          { "internalType": "address", "name": "_staker", "type": "address" }
-        ],
-        "name": "completeUnstake",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "completeUnstake",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "cooldownPeriod",
-        "outputs": [
-          { "internalType": "uint256", "name": "", "type": "uint256" }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          { "internalType": "address", "name": "staker", "type": "address" }
-        ],
-        "name": "cooldowns",
-        "outputs": [
-          { "internalType": "uint248", "name": "amount", "type": "uint248" },
-          { "internalType": "uint256", "name": "endsAt", "type": "uint256" }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          { "internalType": "address", "name": "_staker", "type": "address" }
-        ],
-        "name": "forgive",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          { "internalType": "address", "name": "_wearer", "type": "address" },
-          { "internalType": "uint256", "name": "", "type": "uint256" }
-        ],
-        "name": "getWearerStatus",
-        "outputs": [
-          { "internalType": "bool", "name": "eligible", "type": "bool" },
-          { "internalType": "bool", "name": "standing", "type": "bool" }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "hatId",
-        "outputs": [
-          { "internalType": "uint256", "name": "", "type": "uint256" }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "judgeHat",
-        "outputs": [
-          { "internalType": "uint256", "name": "", "type": "uint256" }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "minStake",
-        "outputs": [
-          { "internalType": "uint248", "name": "", "type": "uint248" }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "recipientHat",
-        "outputs": [
-          { "internalType": "uint256", "name": "", "type": "uint256" }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          { "internalType": "bytes", "name": "_initdata", "type": "bytes" }
-        ],
-        "name": "setUp",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          { "internalType": "address", "name": "_staker", "type": "address" }
-        ],
-        "name": "slash",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          { "internalType": "uint248", "name": "_amount", "type": "uint248" }
-        ],
-        "name": "stake",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          { "internalType": "address", "name": "staker", "type": "address" }
-        ],
-        "name": "stakes",
-        "outputs": [
-          { "internalType": "uint248", "name": "amount", "type": "uint248" },
-          { "internalType": "bool", "name": "slashed", "type": "bool" }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "totalSlashedStakes",
-        "outputs": [
-          { "internalType": "uint248", "name": "", "type": "uint248" }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "version",
-        "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "version_",
-        "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          { "internalType": "address", "name": "_recipient", "type": "address" }
-        ],
-        "name": "withdraw",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      }
-    ]
-  }
-]
+      "abi": [
+        {
+          "inputs": [
+            { "internalType": "string", "name": "_version", "type": "string" }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "constructor"
+        },
+        {
+          "inputs": [],
+          "name": "StakingEligibility_AlreadySlashed",
+          "type": "error"
+        },
+        {
+          "inputs": [],
+          "name": "StakingEligibility_CooldownNotEnded",
+          "type": "error"
+        },
+        {
+          "inputs": [],
+          "name": "StakingEligibility_HatImmutable",
+          "type": "error"
+        },
+        {
+          "inputs": [],
+          "name": "StakingEligibility_InsufficientStake",
+          "type": "error"
+        },
+        {
+          "inputs": [],
+          "name": "StakingEligibility_NoCooldown",
+          "type": "error"
+        },
+        {
+          "inputs": [],
+          "name": "StakingEligibility_NotHatAdmin",
+          "type": "error"
+        },
+        {
+          "inputs": [],
+          "name": "StakingEligibility_NotJudge",
+          "type": "error"
+        },
+        {
+          "inputs": [],
+          "name": "StakingEligibility_NotRecipient",
+          "type": "error"
+        },
+        {
+          "inputs": [],
+          "name": "StakingEligibility_NotSlashed",
+          "type": "error"
+        },
+        {
+          "inputs": [],
+          "name": "StakingEligibility_NothingToWithdraw",
+          "type": "error"
+        },
+        {
+          "inputs": [],
+          "name": "StakingEligibility_TransferFailed",
+          "type": "error"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": false,
+              "internalType": "uint8",
+              "name": "version",
+              "type": "uint8"
+            }
+          ],
+          "name": "Initialized",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": false,
+              "internalType": "uint256",
+              "name": "newDelay",
+              "type": "uint256"
+            }
+          ],
+          "name": "StakingEligibility_CooldownPeriodChanged",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": false,
+              "internalType": "uint256",
+              "name": "hatId",
+              "type": "uint256"
+            },
+            {
+              "indexed": false,
+              "internalType": "address",
+              "name": "instance",
+              "type": "address"
+            },
+            {
+              "indexed": false,
+              "internalType": "address",
+              "name": "token",
+              "type": "address"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint248",
+              "name": "minStake",
+              "type": "uint248"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint256",
+              "name": "judgeHat",
+              "type": "uint256"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint256",
+              "name": "recipientHat",
+              "type": "uint256"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint256",
+              "name": "cooldownPeriod",
+              "type": "uint256"
+            }
+          ],
+          "name": "StakingEligibility_Deployed",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": false,
+              "internalType": "address",
+              "name": "staker",
+              "type": "address"
+            }
+          ],
+          "name": "StakingEligibility_Forgiven",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": false,
+              "internalType": "uint256",
+              "name": "newJudgeHat",
+              "type": "uint256"
+            }
+          ],
+          "name": "StakingEligibility_JudgeHatChanged",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": false,
+              "internalType": "uint248",
+              "name": "newMinStake",
+              "type": "uint248"
+            }
+          ],
+          "name": "StakingEligibility_MinStakeChanged",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": false,
+              "internalType": "uint256",
+              "name": "newRecipientHat",
+              "type": "uint256"
+            }
+          ],
+          "name": "StakingEligibility_RecipientHatChanged",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": false,
+              "internalType": "address",
+              "name": "wearer",
+              "type": "address"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint248",
+              "name": "amount",
+              "type": "uint248"
+            }
+          ],
+          "name": "StakingEligibility_Slashed",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": false,
+              "internalType": "address",
+              "name": "staker",
+              "type": "address"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint248",
+              "name": "amount",
+              "type": "uint248"
+            }
+          ],
+          "name": "StakingEligibility_Staked",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": false,
+              "internalType": "address",
+              "name": "staker",
+              "type": "address"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint248",
+              "name": "amount",
+              "type": "uint248"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint256",
+              "name": "cooldownEnd",
+              "type": "uint256"
+            }
+          ],
+          "name": "StakingEligibility_UnstakeBegun",
+          "type": "event"
+        },
+        {
+          "inputs": [],
+          "name": "HATS",
+          "outputs": [
+            { "internalType": "contract IHats", "name": "", "type": "address" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "IMPLEMENTATION",
+          "outputs": [
+            { "internalType": "address", "name": "", "type": "address" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "TOKEN",
+          "outputs": [
+            { "internalType": "contract IERC20", "name": "", "type": "address" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "uint248", "name": "_amount", "type": "uint248" }
+          ],
+          "name": "beginUnstake",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "_cooldownPeriod",
+              "type": "uint256"
+            }
+          ],
+          "name": "changeCooldownPeriod",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "_judgeHat",
+              "type": "uint256"
+            }
+          ],
+          "name": "changeJudgeHat",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint248",
+              "name": "_minStake",
+              "type": "uint248"
+            }
+          ],
+          "name": "changeMinStake",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "_recipientHat",
+              "type": "uint256"
+            }
+          ],
+          "name": "changeRecipientHat",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "address", "name": "_staker", "type": "address" }
+          ],
+          "name": "completeUnstake",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "completeUnstake",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "cooldownPeriod",
+          "outputs": [
+            { "internalType": "uint256", "name": "", "type": "uint256" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "address", "name": "staker", "type": "address" }
+          ],
+          "name": "cooldowns",
+          "outputs": [
+            { "internalType": "uint248", "name": "amount", "type": "uint248" },
+            { "internalType": "uint256", "name": "endsAt", "type": "uint256" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "address", "name": "_staker", "type": "address" }
+          ],
+          "name": "forgive",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "address", "name": "_wearer", "type": "address" },
+            { "internalType": "uint256", "name": "", "type": "uint256" }
+          ],
+          "name": "getWearerStatus",
+          "outputs": [
+            { "internalType": "bool", "name": "eligible", "type": "bool" },
+            { "internalType": "bool", "name": "standing", "type": "bool" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "hatId",
+          "outputs": [
+            { "internalType": "uint256", "name": "", "type": "uint256" }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "judgeHat",
+          "outputs": [
+            { "internalType": "uint256", "name": "", "type": "uint256" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "minStake",
+          "outputs": [
+            { "internalType": "uint248", "name": "", "type": "uint248" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "recipientHat",
+          "outputs": [
+            { "internalType": "uint256", "name": "", "type": "uint256" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "bytes", "name": "_initdata", "type": "bytes" }
+          ],
+          "name": "setUp",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "address", "name": "_staker", "type": "address" }
+          ],
+          "name": "slash",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "uint248", "name": "_amount", "type": "uint248" }
+          ],
+          "name": "stake",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "address", "name": "staker", "type": "address" }
+          ],
+          "name": "stakes",
+          "outputs": [
+            { "internalType": "uint248", "name": "amount", "type": "uint248" },
+            { "internalType": "bool", "name": "slashed", "type": "bool" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "totalSlashedStakes",
+          "outputs": [
+            { "internalType": "uint248", "name": "", "type": "uint248" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "version",
+          "outputs": [
+            { "internalType": "string", "name": "", "type": "string" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "version_",
+          "outputs": [
+            { "internalType": "string", "name": "", "type": "string" }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "name": "withdraw",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        }
+      ]
+    }
+  ]
+}

--- a/test/withStaticModulesFile.test.ts
+++ b/test/withStaticModulesFile.test.ts
@@ -11,7 +11,7 @@ import type {
   Address,
 } from "viem";
 import type { Anvil } from "@viem/anvil";
-import type { Module } from "../src/types";
+import type { Module, Registry } from "../src/types";
 import "dotenv/config";
 
 describe("Client Tests With a Static Modules File", () => {
@@ -24,6 +24,7 @@ describe("Client Tests With a Static Modules File", () => {
   beforeAll(async () => {
     anvil = createAnvil({
       forkUrl: process.env.GOERLI_RPC,
+      startTimeout: 20000,
     });
     await anvil.start();
 
@@ -43,7 +44,7 @@ describe("Client Tests With a Static Modules File", () => {
 
     const modulesFile = new URL("modules.json", import.meta.url);
     const data = fs.readFileSync(modulesFile, "utf-8");
-    const registryModules: Module[] = JSON.parse(data);
+    const registryModules: Registry = JSON.parse(data);
 
     hatsModulesClient = new HatsModulesClient({
       publicClient,

--- a/test/withStaticModulesFile.test.ts
+++ b/test/withStaticModulesFile.test.ts
@@ -14,7 +14,7 @@ import type { Anvil } from "@viem/anvil";
 import type { Module } from "../src/types";
 import "dotenv/config";
 
-describe("Eligibility Client Tests", () => {
+describe("Client Tests With a Static Modules File", () => {
   let publicClient: PublicClient;
   let walletClient: WalletClient;
   let hatsModulesClient: HatsModulesClient;


### PR DESCRIPTION
This PR add support for batch creating multiple modules in one transaction, via the `batchCreateHatsModule` from HatsModuleFactory.