### PR TITLE
Hat id param in registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatsprotocol/modules-sdk",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "author": "Haberdasher Labs",
   "license": "MIT",
   "main": "dist/modules-sdk.cjs.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
 import { HatsModulesClient } from "./client";
 import { verify, getSchema, solidityToTypescriptType } from "./schemas";
-import type { Module, Factory, Registry, ModuleParameter } from "./types";
+import type {
+  Module,
+  Factory,
+  Registry,
+  ModuleParameter,
+  ArgumentTsType,
+} from "./types";
 
 export { HatsModulesClient, verify, getSchema, solidityToTypescriptType };
-export type { Module, Factory, Registry, ModuleParameter };
+export type { Module, Factory, Registry, ModuleParameter, ArgumentTsType };

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { ZodType } from "zod";
+import type { ArgumentTsType } from "./types";
 
 // Uint
 export const Uint8Schema = z
@@ -851,18 +852,7 @@ export const verify = (val: unknown, type: string): boolean => {
  * @param type - The Solidity type for for which the compatible Typedcript type should be returned.
  * @returns A string matching the compatible Typescript type for the provided Solidity type.
  */
-export const solidityToTypescriptType = (
-  type: string
-):
-  | "number"
-  | "bigint"
-  | "string"
-  | "boolean"
-  | "number[]"
-  | "bigint[]"
-  | "string[]"
-  | "boolean[]"
-  | "unknown" => {
+export const solidityToTypescriptType = (type: string): ArgumentTsType => {
   const schema = typeToSchema[type];
   if (schema === undefined) {
     return "unknown";

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,13 @@ export type Module = {
     block: string;
   }[];
   creationArgs: {
+    hatId: {
+      name: string;
+      description: string;
+      type: string;
+      example: string;
+      displayType: string;
+    };
     immutable: {
       name: string;
       description: string;
@@ -109,3 +116,14 @@ export type Registry = {
   togglesChain: ChainModule;
   modules: Module[];
 };
+
+export type ArgumentTsType =
+  | "number"
+  | "bigint"
+  | "string"
+  | "boolean"
+  | "number[]"
+  | "bigint[]"
+  | "string[]"
+  | "boolean[]"
+  | "unknown";

--- a/test/batchCreate.test.ts
+++ b/test/batchCreate.test.ts
@@ -70,17 +70,17 @@ describe("Batch Create Client Tests", () => {
     mutableArgs = [];
 
     const jokeraceId =
-      "0x7361672a53d246afa75a76b693df21e4592940570a9c934f9cb8afa161c01163";
+      "0xf915b108579dae62bf6d23b311a62ab3dda02f7f3d049b3f4ccbc4cfcf0dcadc";
     const stakingId =
-      "0xf650f73dbb6f081bd193e142f14ec43f4ffbd4e1e0c4a7e1af09dff5cd46f01e";
+      "0xf4dbad25011bb0f2be10227467255124a41571e92e75b28d920b2ac3b6e4295a";
     const erc20Id =
-      "0x7b22c54dd5310e6a320ceef6b50e11a78248b357ac9b59b863b85be404cb0b00";
+      "0x3106b7a7f3153f5c03ee25afee4e7813819fba697a5e635e071d7e883f9dbd4f";
     const erc721Id =
-      "0x397bfaa15ce406221434fa4f46402f4c070952b1054a9f974aac99e2371ae96d";
+      "0x435f4e54d7fe7a3ac636612e08baed44234aeff371b0aa9e1f7b30ba22d9edf7";
     const erc1155Id =
-      "0x85385cde46786f5665f0f9a6f5b539629fe54f152bbf6eef64c431749fda4a77";
+      "0xabcc32da24cdaf054a19bf0fa9292876ace83a98f2ead98bc2ed19c270018e11";
     const claimsHatterId =
-      "0xe755ba756e0617e672bebe30a0d39dcfb7d0d0c2aac2144fd67a660cc7e344e1";
+      "0x9b58749ca97f09f9ef0de791e61eec57e2596f7642e041733e2ec9295b8bfd7e";
 
     const jokeraceModule = hatsModulesClient.getModuleById(
       jokeraceId

--- a/test/eligibilitiesChain.test.ts
+++ b/test/eligibilitiesChain.test.ts
@@ -69,15 +69,15 @@ describe("Batch Create Client Tests", () => {
     mutableArgs = [];
 
     const jokeraceId =
-      "0x7361672a53d246afa75a76b693df21e4592940570a9c934f9cb8afa161c01163";
+      "0xf915b108579dae62bf6d23b311a62ab3dda02f7f3d049b3f4ccbc4cfcf0dcadc";
     const stakingId =
-      "0xf650f73dbb6f081bd193e142f14ec43f4ffbd4e1e0c4a7e1af09dff5cd46f01e";
+      "0xf4dbad25011bb0f2be10227467255124a41571e92e75b28d920b2ac3b6e4295a";
     const erc20Id =
-      "0x7b22c54dd5310e6a320ceef6b50e11a78248b357ac9b59b863b85be404cb0b00";
+      "0x3106b7a7f3153f5c03ee25afee4e7813819fba697a5e635e071d7e883f9dbd4f";
     const erc721Id =
-      "0x397bfaa15ce406221434fa4f46402f4c070952b1054a9f974aac99e2371ae96d";
+      "0x435f4e54d7fe7a3ac636612e08baed44234aeff371b0aa9e1f7b30ba22d9edf7";
     const erc1155Id =
-      "0x85385cde46786f5665f0f9a6f5b539629fe54f152bbf6eef64c431749fda4a77";
+      "0xabcc32da24cdaf054a19bf0fa9292876ace83a98f2ead98bc2ed19c270018e11";
 
     const jokeraceModule = hatsModulesClient.getModuleById(
       jokeraceId

--- a/test/modules.json
+++ b/test/modules.json
@@ -463,6 +463,13 @@
       "implementationAddress": "0xaC208e6668DE569C6ea1db76DeCea70430335Ed5",
       "deployments": [{ "chainId": "5", "block": "9647259" }],
       "creationArgs": {
+        "hatId": {
+          "name": "Target Hat",
+          "description": "The hat ID for which the module will serve as an eligibility.",
+          "type": "uint256",
+          "example": "26959946667150639794667015087019630673637144422540572481103610249216",
+          "displayType": "hat"
+        },
         "immutable": [
           {
             "name": "Owner Hat",
@@ -488,7 +495,7 @@
               "0x0000000000000000000000000000000000000001",
               "0x0000000000000000000000000000000000000002"
             ],
-            "dispalyType": "default"
+            "displayType": "default"
           }
         ]
       },
@@ -829,9 +836,27 @@
       ],
       "parameters": [],
       "type": { "eligibility": false, "toggle": false, "hatter": true },
-      "implementationAddress": "0xC00236108E64A29Cca05aCf4c37ba21eaE348De1",
-      "deployments": [{ "chainId": "5", "block": "9597457" }],
-      "creationArgs": { "immutable": [], "mutable": [] },
+      "implementationAddress": "0x11124220fe23Fd4d25C739508294E6b2305E073C",
+      "deployments": [{ "chainId": "5", "block": "9652513" }],
+      "creationArgs": {
+        "hatId": {
+          "name": "Target Hat",
+          "description": "The ID of the hat which will be claimable.",
+          "type": "uint256",
+          "example": "26959946667150639794667015087019630673637144422540572481103610249216",
+          "displayType": "hat"
+        },
+        "immutable": [],
+        "mutable": [
+          {
+            "name": "Claimable For",
+            "description": "Enables the hat to be claimable on behalf of eligible wearers. Otherwise, will be claimable only by the receiver.",
+            "type": "bool",
+            "example": true,
+            "displayType": "default"
+          }
+        ]
+      },
       "abi": [
         {
           "inputs": [
@@ -1047,6 +1072,13 @@
       "implementationAddress": "0x0089FbD2e0c42F2090890e1d9A3bd8d40E0e2e17",
       "deployments": [{ "chainId": "5", "block": "9608205" }],
       "creationArgs": {
+        "hatId": {
+          "name": "Target Hat",
+          "description": "The hat ID for which the module will serve as an eligibility.",
+          "type": "uint256",
+          "example": "26959946667150639794667015087019630673637144422540572481103610249216",
+          "displayType": "hat"
+        },
         "immutable": [
           {
             "name": "ERC1155 Contract Address",
@@ -1234,6 +1266,13 @@
       "implementationAddress": "0xbA5b218e6685D0607139c06f81442681a32a0EC3",
       "deployments": [{ "chainId": "5", "block": "9611056" }],
       "creationArgs": {
+        "hatId": {
+          "name": "Target Hat",
+          "description": "The hat ID for which the module will serve as an eligibility.",
+          "type": "uint256",
+          "example": "26959946667150639794667015087019630673637144422540572481103610249216",
+          "displayType": "hat"
+        },
         "immutable": [
           {
             "name": "Token Address",
@@ -1389,6 +1428,13 @@
       "implementationAddress": "0xF37cf12fB4493D29270806e826fDDf50dd722bab",
       "deployments": [{ "chainId": "5", "block": "9611065" }],
       "creationArgs": {
+        "hatId": {
+          "name": "Target Hat",
+          "description": "The hat ID for which the module will serve as an eligibility.",
+          "type": "uint256",
+          "example": "26959946667150639794667015087019630673637144422540572481103610249216",
+          "displayType": "hat"
+        },
         "immutable": [
           {
             "name": "Token Address",
@@ -1539,7 +1585,17 @@
       "type": { "eligibility": true, "toggle": false, "hatter": false },
       "implementationAddress": "0xF019B6F0f40104c84f44c25Feb9d4BD808162Bc3",
       "deployments": [{ "chainId": "5", "block": "9647206" }],
-      "creationArgs": { "immutable": [], "mutable": [] },
+      "creationArgs": {
+        "hatId": {
+          "name": "Required Hat",
+          "description": "The ID of the hat which users will be required to wear in order to be eligible.",
+          "type": "uint256",
+          "example": "26959946667150639794667015087019630673637144422540572481103610249216",
+          "displayType": "hat"
+        },
+        "immutable": [],
+        "mutable": []
+      },
       "abi": [
         {
           "inputs": [
@@ -1669,6 +1725,13 @@
       "implementationAddress": "0x2bb30E1786a656EC6cD81e79EEf1A28607c9AE5A",
       "deployments": [{ "chainId": "5", "block": "9597388" }],
       "creationArgs": {
+        "hatId": {
+          "name": "Target Hat",
+          "description": "The hat ID for which the module will serve as an eligibility.",
+          "type": "uint256",
+          "example": "26959946667150639794667015087019630673637144422540572481103610249216",
+          "displayType": "hat"
+        },
         "immutable": [
           {
             "name": "Admin Hat",
@@ -1938,7 +2001,17 @@
       "type": { "eligibility": true, "toggle": true, "hatter": false },
       "implementationAddress": "0x5790e25C58cAe56EB243F0bacE67C38284417771",
       "deployments": [{ "chainId": "5", "block": "9647239" }],
-      "creationArgs": { "immutable": [], "mutable": [] },
+      "creationArgs": {
+        "hatId": {
+          "name": "Eligibility/Toggle Hat",
+          "description": "The ID of the hat for which its wearers will serve as toggle/eligibility.",
+          "type": "uint256",
+          "example": "26959946667150639794667015087019630673637144422540572481103610249216",
+          "displayType": "hat"
+        },
+        "immutable": [],
+        "mutable": []
+      },
       "abi": [
         {
           "inputs": [
@@ -2067,6 +2140,13 @@
       "implementationAddress": "0xFb6bD2e96B123d0854064823f6cb59420A285C00",
       "deployments": [{ "chainId": "5", "block": "9597342" }],
       "creationArgs": {
+        "hatId": {
+          "name": "Branch Root",
+          "description": "The ID of the branch root hat.",
+          "type": "uint256",
+          "example": "26959946667150639794667015087019630673637144422540572481103610249216",
+          "displayType": "hat"
+        },
         "immutable": [],
         "mutable": [
           {
@@ -2321,6 +2401,13 @@
       "implementationAddress": "0x9E01030aF633Be5a439DF122F2eEf750b44B8aC7",
       "deployments": [{ "chainId": "5", "block": "9597271" }],
       "creationArgs": {
+        "hatId": {
+          "name": "Target Hat",
+          "description": "The hat ID for which the module will serve as an eligibility.",
+          "type": "uint256",
+          "example": "26959946667150639794667015087019630673637144422540572481103610249216",
+          "displayType": "hat"
+        },
         "immutable": [
           {
             "name": "Staking Token",

--- a/test/withRegistry.test.ts
+++ b/test/withRegistry.test.ts
@@ -59,9 +59,7 @@ describe("Eligibility Client Tests", () => {
   test("Test create all modules", async () => {
     const modules = hatsModulesClient.getAllModules();
     for (const [id, module] of Object.entries(modules)) {
-      const hatId = BigInt(
-        "0x0000000100000000000000000000000000000000000000000000000000000000"
-      );
+      const hatId = BigInt(module.creationArgs.hatId.example);
       const immutableArgs: unknown[] = [];
       const mutableArgs: unknown[] = [];
 

--- a/test/withStaticModulesFile.test.ts
+++ b/test/withStaticModulesFile.test.ts
@@ -60,12 +60,10 @@ describe("Client Tests With a Static Modules File", () => {
 
   test("Test create new jokerace instance and get instace parameters", async () => {
     const jokeraceId =
-      "0x7361672a53d246afa75a76b693df21e4592940570a9c934f9cb8afa161c01163";
+      "0xf915b108579dae62bf6d23b311a62ab3dda02f7f3d049b3f4ccbc4cfcf0dcadc";
     const module = hatsModulesClient.getModuleById(jokeraceId) as Module;
 
-    const hatId = BigInt(
-      "0x0000000100000000000000000000000000000000000000000000000000000000"
-    );
+    const hatId = BigInt(module.creationArgs.hatId.example);
     const immutableArgs: unknown[] = [];
     const mutableArgs: unknown[] = [];
 
@@ -166,7 +164,7 @@ describe("Client Tests With a Static Modules File", () => {
 
   test("Test get jokerace functions names", () => {
     const jokeraceId =
-      "0x7361672a53d246afa75a76b693df21e4592940570a9c934f9cb8afa161c01163";
+      "0xf915b108579dae62bf6d23b311a62ab3dda02f7f3d049b3f4ccbc4cfcf0dcadc";
     const functions = hatsModulesClient.getFunctionsInModule(jokeraceId);
     const expectedFunctions = [
       {
@@ -256,12 +254,10 @@ describe("Client Tests With a Static Modules File", () => {
 
   test("Test create new staking instance and get instace parameters", async () => {
     const stakingId =
-      "0xf650f73dbb6f081bd193e142f14ec43f4ffbd4e1e0c4a7e1af09dff5cd46f01e";
+      "0xf4dbad25011bb0f2be10227467255124a41571e92e75b28d920b2ac3b6e4295a";
     const module = hatsModulesClient.getModuleById(stakingId) as Module;
 
-    const hatId = BigInt(
-      "0x0000000100000000000000000000000000000000000000000000000000000000"
-    );
+    const hatId = BigInt(module.creationArgs.hatId.example);
     const immutableArgs: unknown[] = [];
     const mutableArgs: unknown[] = [];
 
@@ -369,12 +365,10 @@ describe("Client Tests With a Static Modules File", () => {
 
   test("Test create new erc20 eligibility instance and get instance parameters", async () => {
     const erc20Id =
-      "0x7b22c54dd5310e6a320ceef6b50e11a78248b357ac9b59b863b85be404cb0b00";
+      "0x3106b7a7f3153f5c03ee25afee4e7813819fba697a5e635e071d7e883f9dbd4f";
     const module = hatsModulesClient.getModuleById(erc20Id) as Module;
 
-    const hatId = BigInt(
-      "0x0000000100000000000000000000000000000000000000000000000000000000"
-    );
+    const hatId = BigInt(module.creationArgs.hatId.example);
     const immutableArgs: unknown[] = [];
     const mutableArgs: unknown[] = [];
 
@@ -455,12 +449,10 @@ describe("Client Tests With a Static Modules File", () => {
 
   test("Test create new erc721 eligibility instance and get instance parameters", async () => {
     const erc721Id =
-      "0x397bfaa15ce406221434fa4f46402f4c070952b1054a9f974aac99e2371ae96d";
+      "0x435f4e54d7fe7a3ac636612e08baed44234aeff371b0aa9e1f7b30ba22d9edf7";
     const module = hatsModulesClient.getModuleById(erc721Id) as Module;
 
-    const hatId = BigInt(
-      "0x0000000100000000000000000000000000000000000000000000000000000000"
-    );
+    const hatId = BigInt(module.creationArgs.hatId.example);
     const immutableArgs: unknown[] = [];
     const mutableArgs: unknown[] = [];
 
@@ -541,12 +533,10 @@ describe("Client Tests With a Static Modules File", () => {
 
   test("Test create new erc1155 eligibility instance and get instance parameters", async () => {
     const erc1155Id =
-      "0x85385cde46786f5665f0f9a6f5b539629fe54f152bbf6eef64c431749fda4a77";
+      "0xabcc32da24cdaf054a19bf0fa9292876ace83a98f2ead98bc2ed19c270018e11";
     const module = hatsModulesClient.getModuleById(erc1155Id) as Module;
 
-    const hatId = BigInt(
-      "0x0000000100000000000000000000000000000000000000000000000000000000"
-    );
+    const hatId = BigInt(module.creationArgs.hatId.example);
     const immutableArgs: unknown[] = [];
     const mutableArgs: unknown[] = [];
     for (let i = 0; i < module.creationArgs.immutable.length; i++) {
@@ -646,13 +636,26 @@ describe("Client Tests With a Static Modules File", () => {
 
   test("Test create new claims hatter instance", async () => {
     const claimsHatterId =
-      "0xe755ba756e0617e672bebe30a0d39dcfb7d0d0c2aac2144fd67a660cc7e344e1";
+      "0x9b58749ca97f09f9ef0de791e61eec57e2596f7642e041733e2ec9295b8bfd7e";
     const module = hatsModulesClient.getModuleById(claimsHatterId) as Module;
-    const hatId = BigInt(
-      "0x0000000100000000000000000000000000000000000000000000000000000000"
-    );
+    const hatId = BigInt(module.creationArgs.hatId.example);
     const immutableArgs: unknown[] = [];
     const mutableArgs: unknown[] = [];
+
+    for (let i = 0; i < module.creationArgs.mutable.length; i++) {
+      let arg: unknown;
+      const exampleArg = module.creationArgs.mutable[i].example;
+      const tsType = solidityToTypescriptType(
+        module.creationArgs.mutable[i].type
+      );
+      if (tsType === "bigint") {
+        arg = BigInt(exampleArg as string);
+      } else {
+        arg = exampleArg;
+      }
+
+      mutableArgs.push(arg);
+    }
 
     const res = await hatsModulesClient.createNewInstance({
       account: deployerAccount,
@@ -674,14 +677,14 @@ describe("Client Tests With a Static Modules File", () => {
 
   test("Test get module by implementation", async () => {
     const claimsHatterId =
-      "0xe755ba756e0617e672bebe30a0d39dcfb7d0d0c2aac2144fd67a660cc7e344e1";
+      "0x9b58749ca97f09f9ef0de791e61eec57e2596f7642e041733e2ec9295b8bfd7e";
     const claimsHatterModule = hatsModulesClient.getModuleById(
       claimsHatterId
     ) as Module;
 
     expect(
       hatsModulesClient.getModuleByImplementaion(
-        "0xC00236108E64A29Cca05aCf4c37ba21eaE348De1"
+        "0x11124220fe23Fd4d25C739508294E6b2305E073C"
       )
     ).toEqual(claimsHatterModule);
   });


### PR DESCRIPTION
- Update the SDK following the addition of a hat ID param  for each module in the registry
- Export the `ArgumentTsType` type