### PR TITLE
Rulesets with live params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatsprotocol/modules-sdk",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "Haberdasher Labs",
   "license": "MIT",
   "main": "dist/modules-sdk.cjs.js",

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,4 +112,9 @@ export type ModuleCreationArgs = {
 export type Ruleset = {
   module: Module;
   address: `0x${string}`;
+  liveParams?: ModuleParameter[];
 }[];
+
+export type GetRulesetsConfig = {
+  includeLiveParams?: boolean;
+};

--- a/test/eligibilitiesChain.test.ts
+++ b/test/eligibilitiesChain.test.ts
@@ -425,7 +425,9 @@ describe("Batch Create Client Tests", () => {
 
   describe("get rulesets tests", () => {
     test("Scenario 1", async () => {
-      const rulesets = await hatsModulesClient.getRulesets(chain1);
+      const rulesets = await hatsModulesClient.getRulesets(chain1, {
+        includeLiveParams: true,
+      });
       expect(rulesets).toBeDefined();
       if (rulesets !== undefined) {
         expect(rulesets.length).toBe(2);
@@ -435,6 +437,13 @@ describe("Batch Create Client Tests", () => {
         expect(ruleset1.length).toBe(2);
         expect(ruleset1[0].address).toBe(jokeraceInstance);
         expect(ruleset1[0].module.name).toBe("JokeRace Eligibility");
+        expect(ruleset1[0].liveParams).toBeDefined();
+        expect(ruleset1[0].liveParams?.length).toBe(4);
+        if (ruleset1[0].liveParams !== undefined) {
+          expect(ruleset1[0].liveParams[0].value).toBe(
+            26959946667150639794667015087019630673637144422540572481103610249216n
+          );
+        }
         expect(ruleset1[1].address).toBe(stakingInstance);
         expect(ruleset1[1].module.name).toBe("Staking Eligibility");
 


### PR DESCRIPTION
Optional fetch the live params of each module in the rulesets, when using the `getRulesets` function