### PR TITLE
Identify modules by ID and version

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1438,7 +1438,7 @@ export class HatsModulesClient {
         transactionHash: receipt.transactionHash,
       };
     } catch (err) {
-      getModuleFunctionError(err, moduleId);
+      getModuleFunctionError(err, moduleId, moduleVersion);
     }
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -136,6 +136,7 @@ export class HatsModulesClient {
   async createNewInstance({
     account,
     moduleId,
+    moduleVersion,
     hatId,
     immutableArgs,
     mutableArgs,
@@ -143,6 +144,7 @@ export class HatsModulesClient {
   }: {
     account: Account | Address;
     moduleId: string;
+    moduleVersion: string;
     hatId: bigint;
     immutableArgs: unknown[];
     mutableArgs: unknown[];
@@ -159,7 +161,7 @@ export class HatsModulesClient {
       );
     }
 
-    const module = this.getModuleById(moduleId);
+    const module = this.getModuleById(moduleId, moduleVersion);
     if (module === undefined) {
       throw new ModuleNotAvailableError(
         `Error: Module with id ${moduleId} does not exist`
@@ -240,14 +242,14 @@ export class HatsModulesClient {
    */
   async batchCreateNewInstances({
     account,
-    moduleIds,
+    moduleIdsAndVersions,
     hatIds,
     immutableArgsArray,
     mutableArgsArray,
     saltNonces,
   }: {
     account: Account | Address;
-    moduleIds: string[];
+    moduleIdsAndVersions: { id: string; version: string }[];
     hatIds: bigint[];
     immutableArgsArray: unknown[][];
     mutableArgsArray: unknown[][];
@@ -269,11 +271,14 @@ export class HatsModulesClient {
     const encodedMutableArgsArray: Array<`0x${string}`> = [];
     const saltNoncesToUse: Array<bigint> = [];
 
-    for (let i = 0; i < moduleIds.length; i++) {
-      const module = this.getModuleById(moduleIds[i]);
+    for (let i = 0; i < moduleIdsAndVersions.length; i++) {
+      const module = this.getModuleById(
+        moduleIdsAndVersions[i].id,
+        moduleIdsAndVersions[i].version
+      );
       if (module === undefined) {
         throw new ModuleNotAvailableError(
-          `Error: Module with id ${moduleIds[i]} does not exist`
+          `Error: Module with id ${moduleIdsAndVersions[i].id}-${moduleIdsAndVersions[i].version} does not exist`
         );
       }
 
@@ -350,11 +355,13 @@ export class HatsModulesClient {
    */
   async predictHatsModuleAddress({
     moduleId,
+    moduleVersion,
     hatId,
     immutableArgs,
     saltNonce,
   }: {
     moduleId: string;
+    moduleVersion: string;
     hatId: bigint;
     immutableArgs: unknown[];
     saltNonce: bigint;
@@ -365,7 +372,7 @@ export class HatsModulesClient {
       );
     }
 
-    const module = this.getModuleById(moduleId);
+    const module = this.getModuleById(moduleId, moduleVersion);
     if (module === undefined) {
       throw new ModuleNotAvailableError(
         `Module with id ${moduleId} does not exist`
@@ -413,11 +420,13 @@ export class HatsModulesClient {
    */
   async isModuleDeployed({
     moduleId,
+    moduleVersion,
     hatId,
     immutableArgs,
     saltNonce,
   }: {
     moduleId: string;
+    moduleVersion: string;
     hatId: bigint;
     immutableArgs: unknown[];
     saltNonce: bigint;
@@ -428,7 +437,7 @@ export class HatsModulesClient {
       );
     }
 
-    const module = this.getModuleById(moduleId);
+    const module = this.getModuleById(moduleId, moduleVersion);
     if (module === undefined) {
       throw new ModuleNotAvailableError(
         `Error: Module with id ${moduleId} does not exist`
@@ -1229,14 +1238,14 @@ export class HatsModulesClient {
    * @param moduleId - The module ID.
    * @returns The module matching the provided ID.
    */
-  getModuleById(moduleId: string): Module | undefined {
+  getModuleById(moduleId: string, moduleVersion: string): Module | undefined {
     if (this._modules === undefined) {
       throw new ClientNotPreparedError(
         "Error: Client has not been initialized, requires a call to the prepare function"
       );
     }
 
-    return this._modules[moduleId];
+    return this._modules[`${moduleId}-${moduleVersion}`];
   }
 
   /**
@@ -1377,12 +1386,14 @@ export class HatsModulesClient {
   async callInstanceWriteFunction({
     account,
     moduleId,
+    moduleVersion,
     instance,
     func,
     args,
   }: {
     account: Account | Address;
     moduleId: string;
+    moduleVersion: string;
     instance: Address;
     func: WriteFunction;
     args: unknown[];
@@ -1398,7 +1409,7 @@ export class HatsModulesClient {
       );
     }
 
-    const module = this.getModuleById(moduleId);
+    const module = this.getModuleById(moduleId, moduleVersion);
     if (module === undefined) {
       throw new ModuleNotAvailableError(
         `Error: Module with id ${moduleId} does not exist`

--- a/src/client.ts
+++ b/src/client.ts
@@ -113,7 +113,7 @@ export class HatsModulesClient {
       });
 
       if (moduleSupportedInChain) {
-        const moduleId: string = module.implementationAddress;
+        const moduleId: string = `${module.id}-${module.version}`;
 
         if (this._modules !== undefined) {
           this._modules[moduleId] = module;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -322,7 +322,11 @@ export class StakingEligibility_NotSlashedError extends Error {
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-export function getModuleFunctionError(err: unknown, moduleId: string): never {
+export function getModuleFunctionError(
+  err: unknown,
+  moduleId: string,
+  moduleVersion: string
+): never {
   if (err instanceof BaseError) {
     const revertError = err.walk(
       (err) => err instanceof ContractFunctionRevertedError
@@ -331,7 +335,10 @@ export function getModuleFunctionError(err: unknown, moduleId: string): never {
       const errorName = revertError.data?.errorName ?? "";
 
       // AllowList Eligibility error
-      if (moduleId === "0xaC208e6668DE569C6ea1db76DeCea70430335Ed5") {
+      if (
+        moduleId === "haberdasher-labs_allowlist-eligibility" &&
+        moduleVersion === "v0.1.0"
+      ) {
         switch (errorName) {
           case "AllowlistEligibility_NotOwner": {
             throw new AllowlistEligibility_NotOwnerError(
@@ -360,7 +367,10 @@ export function getModuleFunctionError(err: unknown, moduleId: string): never {
       }
 
       // Hat Elections Eligibility error
-      if (moduleId === "0xd3b916a8F0C4f9D1d5B6Af29c3C012dbd4f3149E") {
+      if (
+        moduleId === "haberdasher-labs_hats-election-eligibility" &&
+        moduleVersion === "v0.2.0"
+      ) {
         switch (errorName) {
           case "NotBallotBox": {
             throw new HatsElectionEligibility_NotBallotBoxError(
@@ -404,7 +414,10 @@ export function getModuleFunctionError(err: unknown, moduleId: string): never {
       }
 
       // JokeRace Eligibility error
-      if (moduleId === "0xAE0e56A0c509dA713722c1aFFcF4B5f1C6CDc73a") {
+      if (
+        moduleId === "haberdasher-labs_jokerace-eligibility" &&
+        moduleVersion === "v0.2.0"
+      ) {
         switch (errorName) {
           case "JokeraceEligibility_ContestNotCompleted": {
             throw new JokeraceEligibility_ContestNotCompletedError(
@@ -438,7 +451,10 @@ export function getModuleFunctionError(err: unknown, moduleId: string): never {
       }
 
       // Passthrough Eligibility error
-      if (moduleId === "0x050079a8fbFCE76818C62481BA015b89567D2d35") {
+      if (
+        moduleId === "haberdasher-labs_passthrough-module" &&
+        moduleVersion === "v0.1.0"
+      ) {
         switch (errorName) {
           case "NotAuthorized": {
             throw new PassthroughEligibility_NotAuthorizedError(
@@ -452,7 +468,10 @@ export function getModuleFunctionError(err: unknown, moduleId: string): never {
       }
 
       // Season Toggle error
-      if (moduleId === "0xFb6bD2e96B123d0854064823f6cb59420A285C00") {
+      if (
+        moduleId === "haberdasher-labs_season-toggle" &&
+        moduleVersion === "v0.1.0"
+      ) {
         switch (errorName) {
           case "SeasonToggle_NotBranchAdmin": {
             throw new SeasonToggle_NotBranchAdminError(
@@ -481,7 +500,10 @@ export function getModuleFunctionError(err: unknown, moduleId: string): never {
       }
 
       // Staking Eligibility error
-      if (moduleId === "0x9E01030aF633Be5a439DF122F2eEf750b44B8aC7") {
+      if (
+        moduleId === "haberdasher-labs_staking-eligibility" &&
+        moduleVersion === "v0.1.0"
+      ) {
         switch (errorName) {
           case "StakingEligibility_InsufficientStake": {
             throw new StakingEligibility_InsufficientStakeError(
@@ -549,6 +571,7 @@ export function getModuleFunctionError(err: unknown, moduleId: string): never {
         `Error: module function reverted with error name ${errorName}`
       );
     }
+    throw err;
   } else {
     if (err instanceof Error) {
       throw err;

--- a/test/batchCreate.test.ts
+++ b/test/batchCreate.test.ts
@@ -67,19 +67,37 @@ describe("Batch Create Client Tests", () => {
     immutableArgs = [];
     mutableArgs = [];
 
-    const jokeraceId = "0xAE0e56A0c509dA713722c1aFFcF4B5f1C6CDc73a";
-    const stakingId = "0x9E01030aF633Be5a439DF122F2eEf750b44B8aC7";
-    const erc20Id = "0xbA5b218e6685D0607139c06f81442681a32a0EC3";
-    const erc721Id = "0xF37cf12fB4493D29270806e826fDDf50dd722bab";
-    const erc1155Id = "0x0089FbD2e0c42F2090890e1d9A3bd8d40E0e2e17";
+    const jokeraceId = "haberdasher-labs_jokerace-eligibility";
+    const jokeraceVersion = "v0.2.0";
+    const stakingId = "haberdasher-labs_staking-eligibility";
+    const stakingVersion = "v0.1.0";
+    const erc20Id = "pumpedlunch_erc20-eligibility";
+    const erc20Version = "v0.1.0";
+    const erc721Id = "pumpedlunch_erc721-eligibility";
+    const erc721Version = "v0.1.0";
+    const erc1155Id = "pumpedlunch_erc1155-eligibility";
+    const erc1155Version = "v0.1.0";
 
     const jokeraceModule = hatsModulesClient.getModuleById(
-      jokeraceId
+      jokeraceId,
+      jokeraceVersion
     ) as Module;
-    const stakingModule = hatsModulesClient.getModuleById(stakingId) as Module;
-    const erc20Module = hatsModulesClient.getModuleById(erc20Id) as Module;
-    const erc721Module = hatsModulesClient.getModuleById(erc721Id) as Module;
-    const erc1155Module = hatsModulesClient.getModuleById(erc1155Id) as Module;
+    const stakingModule = hatsModulesClient.getModuleById(
+      stakingId,
+      stakingVersion
+    ) as Module;
+    const erc20Module = hatsModulesClient.getModuleById(
+      erc20Id,
+      erc20Version
+    ) as Module;
+    const erc721Module = hatsModulesClient.getModuleById(
+      erc721Id,
+      erc721Version
+    ) as Module;
+    const erc1155Module = hatsModulesClient.getModuleById(
+      erc1155Id,
+      erc1155Version
+    ) as Module;
 
     jokeraceAbi = jokeraceModule.abi;
     stakingAbi = stakingModule.abi;
@@ -94,12 +112,12 @@ describe("Batch Create Client Tests", () => {
       erc721Module,
       erc1155Module,
     ];
-    const moduleIds: string[] = [
-      jokeraceId,
-      stakingId,
-      erc20Id,
-      erc721Id,
-      erc1155Id,
+    const moduleIdsAndVersions: { id: string; version: string }[] = [
+      { id: jokeraceId, version: jokeraceVersion },
+      { id: stakingId, version: stakingVersion },
+      { id: erc20Id, version: erc20Version },
+      { id: erc721Id, version: erc721Version },
+      { id: erc1155Id, version: erc1155Version },
     ];
     const hatIds: bigint[] = [
       BigInt(
@@ -163,7 +181,8 @@ describe("Batch Create Client Tests", () => {
 
     const res = await hatsModulesClient.batchCreateNewInstances({
       account: deployerAccount,
-      moduleIds,
+      moduleIdsAndVersions,
+
       hatIds,
       immutableArgsArray: immutableArgs,
       mutableArgsArray: mutableArgs,

--- a/test/eligibilitiesChain.test.ts
+++ b/test/eligibilitiesChain.test.ts
@@ -73,19 +73,37 @@ describe("Batch Create Client Tests", () => {
     immutableArgs = [];
     mutableArgs = [];
 
-    const jokeraceId = "0xAE0e56A0c509dA713722c1aFFcF4B5f1C6CDc73a";
-    const stakingId = "0x9E01030aF633Be5a439DF122F2eEf750b44B8aC7";
-    const erc20Id = "0xbA5b218e6685D0607139c06f81442681a32a0EC3";
-    const erc721Id = "0xF37cf12fB4493D29270806e826fDDf50dd722bab";
-    const erc1155Id = "0x0089FbD2e0c42F2090890e1d9A3bd8d40E0e2e17";
+    const jokeraceId = "haberdasher-labs_jokerace-eligibility";
+    const jokeraceVersion = "v0.2.0";
+    const stakingId = "haberdasher-labs_staking-eligibility";
+    const stakingVersion = "v0.1.0";
+    const erc20Id = "pumpedlunch_erc20-eligibility";
+    const erc20Version = "v0.1.0";
+    const erc721Id = "pumpedlunch_erc721-eligibility";
+    const erc721Version = "v0.1.0";
+    const erc1155Id = "pumpedlunch_erc1155-eligibility";
+    const erc1155Version = "v0.1.0";
 
     const jokeraceModule = hatsModulesClient.getModuleById(
-      jokeraceId
+      jokeraceId,
+      jokeraceVersion
     ) as Module;
-    const stakingModule = hatsModulesClient.getModuleById(stakingId) as Module;
-    const erc20Module = hatsModulesClient.getModuleById(erc20Id) as Module;
-    const erc721Module = hatsModulesClient.getModuleById(erc721Id) as Module;
-    const erc1155Module = hatsModulesClient.getModuleById(erc1155Id) as Module;
+    const stakingModule = hatsModulesClient.getModuleById(
+      stakingId,
+      stakingVersion
+    ) as Module;
+    const erc20Module = hatsModulesClient.getModuleById(
+      erc20Id,
+      erc20Version
+    ) as Module;
+    const erc721Module = hatsModulesClient.getModuleById(
+      erc721Id,
+      erc721Version
+    ) as Module;
+    const erc1155Module = hatsModulesClient.getModuleById(
+      erc1155Id,
+      erc1155Version
+    ) as Module;
 
     const modules: Module[] = [
       jokeraceModule,
@@ -94,12 +112,12 @@ describe("Batch Create Client Tests", () => {
       erc721Module,
       erc1155Module,
     ];
-    const moduleIds: string[] = [
-      jokeraceId,
-      stakingId,
-      erc20Id,
-      erc721Id,
-      erc1155Id,
+    const moduleIdsAndVersions: { id: string; version: string }[] = [
+      { id: jokeraceId, version: jokeraceVersion },
+      { id: stakingId, version: stakingVersion },
+      { id: erc20Id, version: erc20Version },
+      { id: erc721Id, version: erc721Version },
+      { id: erc1155Id, version: erc1155Version },
     ];
     const hatIds: bigint[] = [
       BigInt(
@@ -163,7 +181,7 @@ describe("Batch Create Client Tests", () => {
 
     const res = await hatsModulesClient.batchCreateNewInstances({
       account: deployerAccount,
-      moduleIds,
+      moduleIdsAndVersions,
       hatIds,
       immutableArgsArray: immutableArgs,
       mutableArgsArray: mutableArgs,

--- a/test/withRegistry.test.ts
+++ b/test/withRegistry.test.ts
@@ -71,14 +71,11 @@ describe("Eligibility Client Tests", () => {
     for (const [id, module] of Object.entries(modules)) {
       // jokerace and baal staking eligibilities deployment falis due to dependency on external contracts
       if (
-        id === "0xAE0e56A0c509dA713722c1aFFcF4B5f1C6CDc73a" ||
-        id === "0xa1E79f78630F77436C001Af44893A2720180E19F" ||
-        id === "0x0Bb0a2B9bc5Da206fead8e87D7Cbc6fCBa455320"
+        id === "haberdasher-labs_baal-staking-eligibility-v0.1.0" ||
+        id === "haberdasher-labs_jokerace-eligibility-v0.3.0"
       ) {
         continue;
       }
-
-      console.log(`Deploying an instance of module ${module.name}`);
 
       const hatId = module.creationArgs.useHatId
         ? BigInt(
@@ -124,7 +121,8 @@ describe("Eligibility Client Tests", () => {
 
       // check that module is not yet deployed
       const isDeployedPrev = await hatsModulesClient.isModuleDeployed({
-        moduleId: id,
+        moduleId: module.id,
+        moduleVersion: module.version,
         hatId: hatId,
         immutableArgs: immutableArgs,
         saltNonce,
@@ -134,7 +132,8 @@ describe("Eligibility Client Tests", () => {
       // create a new instance
       const res = await hatsModulesClient.createNewInstance({
         account: deployerAccount,
-        moduleId: id,
+        moduleId: module.id,
+        moduleVersion: module.version,
         hatId: hatId,
         immutableArgs: immutableArgs,
         mutableArgs: mutableArgs,
@@ -157,7 +156,8 @@ describe("Eligibility Client Tests", () => {
       // predict module address
       const predictedAddress = await hatsModulesClient.predictHatsModuleAddress(
         {
-          moduleId: id,
+          moduleId: module.id,
+          moduleVersion: module.version,
           hatId: hatId,
           immutableArgs: immutableArgs,
           saltNonce,
@@ -167,7 +167,8 @@ describe("Eligibility Client Tests", () => {
 
       // check that module is deployed
       const isDeployedAfter = await hatsModulesClient.isModuleDeployed({
-        moduleId: id,
+        moduleId: module.id,
+        moduleVersion: module.version,
         hatId: hatId,
         immutableArgs: immutableArgs,
         saltNonce,

--- a/test/withStaticModulesFile.test.ts
+++ b/test/withStaticModulesFile.test.ts
@@ -123,8 +123,12 @@ describe("Client Tests With a Static Modules File", () => {
   });
 
   test("Test create new jokerace instance and get instace parameters", async () => {
-    const jokeraceId = "0xAE0e56A0c509dA713722c1aFFcF4B5f1C6CDc73a";
-    const module = hatsModulesClient.getModuleById(jokeraceId) as Module;
+    const jokeraceId = "haberdasher-labs_jokerace-eligibility";
+    const jokeraceVersion = "v0.2.0";
+    const module = hatsModulesClient.getModuleById(
+      jokeraceId,
+      jokeraceVersion
+    ) as Module;
 
     const hatId = BigInt(
       "0x0000000100000000000000000000000000000000000000000000000000000000"
@@ -165,6 +169,7 @@ describe("Client Tests With a Static Modules File", () => {
     const res = await hatsModulesClient.createNewInstance({
       account: deployerAccount,
       moduleId: jokeraceId,
+      moduleVersion: jokeraceVersion,
       hatId: hatId,
       immutableArgs: immutableArgs,
       mutableArgs: mutableArgs,
@@ -228,8 +233,12 @@ describe("Client Tests With a Static Modules File", () => {
   }, 10000);
 
   test("Test create new staking instance and get instace parameters", async () => {
-    const stakingId = "0x9E01030aF633Be5a439DF122F2eEf750b44B8aC7";
-    const module = hatsModulesClient.getModuleById(stakingId) as Module;
+    const stakingId = "haberdasher-labs_staking-eligibility";
+    const stakingVersion = "v0.1.0";
+    const module = hatsModulesClient.getModuleById(
+      stakingId,
+      stakingVersion
+    ) as Module;
 
     const hatId = BigInt(
       "0x0000000100000000000000000000000000000000000000000000000000000000"
@@ -270,6 +279,7 @@ describe("Client Tests With a Static Modules File", () => {
     const res = await hatsModulesClient.createNewInstance({
       account: deployerAccount,
       moduleId: stakingId,
+      moduleVersion: stakingVersion,
       hatId: hatId,
       immutableArgs: immutableArgs,
       mutableArgs: mutableArgs,
@@ -340,8 +350,12 @@ describe("Client Tests With a Static Modules File", () => {
   });
 
   test("Test create new erc20 eligibility instance and get instance parameters", async () => {
-    const erc20Id = "0xbA5b218e6685D0607139c06f81442681a32a0EC3";
-    const module = hatsModulesClient.getModuleById(erc20Id) as Module;
+    const erc20Id = "pumpedlunch_erc20-eligibility";
+    const erc20Version = "v0.1.0";
+    const module = hatsModulesClient.getModuleById(
+      erc20Id,
+      erc20Version
+    ) as Module;
 
     const hatId = BigInt(
       "0x0000000100000000000000000000000000000000000000000000000000000000"
@@ -382,6 +396,7 @@ describe("Client Tests With a Static Modules File", () => {
     const res = await hatsModulesClient.createNewInstance({
       account: deployerAccount,
       moduleId: erc20Id,
+      moduleVersion: erc20Version,
       hatId: hatId,
       immutableArgs: immutableArgs,
       mutableArgs: mutableArgs,
@@ -427,8 +442,12 @@ describe("Client Tests With a Static Modules File", () => {
   });
 
   test("Test create new erc721 eligibility instance and get instance parameters", async () => {
-    const erc721Id = "0xF37cf12fB4493D29270806e826fDDf50dd722bab";
-    const module = hatsModulesClient.getModuleById(erc721Id) as Module;
+    const erc721Id = "pumpedlunch_erc721-eligibility";
+    const erc721Version = "v0.1.0";
+    const module = hatsModulesClient.getModuleById(
+      erc721Id,
+      erc721Version
+    ) as Module;
 
     const hatId = BigInt(
       "0x0000000100000000000000000000000000000000000000000000000000000000"
@@ -469,6 +488,7 @@ describe("Client Tests With a Static Modules File", () => {
     const res = await hatsModulesClient.createNewInstance({
       account: deployerAccount,
       moduleId: erc721Id,
+      moduleVersion: erc721Version,
       hatId: hatId,
       immutableArgs: immutableArgs,
       mutableArgs: mutableArgs,
@@ -514,8 +534,12 @@ describe("Client Tests With a Static Modules File", () => {
   });
 
   test("Test create new erc1155 eligibility instance and get instance parameters", async () => {
-    const erc1155Id = "0x0089FbD2e0c42F2090890e1d9A3bd8d40E0e2e17";
-    const module = hatsModulesClient.getModuleById(erc1155Id) as Module;
+    const erc1155Id = "pumpedlunch_erc1155-eligibility";
+    const erc1155Version = "v0.1.0";
+    const module = hatsModulesClient.getModuleById(
+      erc1155Id,
+      erc1155Version
+    ) as Module;
 
     const hatId = BigInt(
       "0x0000000100000000000000000000000000000000000000000000000000000000"
@@ -557,6 +581,7 @@ describe("Client Tests With a Static Modules File", () => {
     const res = await hatsModulesClient.createNewInstance({
       account: deployerAccount,
       moduleId: erc1155Id,
+      moduleVersion: erc1155Version,
       hatId: hatId,
       immutableArgs: immutableArgs,
       mutableArgs: mutableArgs,
@@ -620,9 +645,11 @@ describe("Client Tests With a Static Modules File", () => {
   });
 
   test("Test get module by implementation", async () => {
-    const claimsHatterId = "0xB985eA1be961f7c4A4C45504444C02c88c4fdEF9";
+    const claimsHatterId = "haberdasher-labs_multi-claims-hatter";
+    const claimsHatterVersion = "v0.1.0";
     const claimsHatterModule = hatsModulesClient.getModuleById(
-      claimsHatterId
+      claimsHatterId,
+      claimsHatterVersion
     ) as Module;
 
     expect(

--- a/test/writeFunctions.test.ts
+++ b/test/writeFunctions.test.ts
@@ -127,7 +127,8 @@ describe("Write Functions Client Tests", () => {
     beforeAll(async () => {
       const resAllowListInstance = await hatsModulesClient.createNewInstance({
         account: account1,
-        moduleId: "0xaC208e6668DE569C6ea1db76DeCea70430335Ed5",
+        moduleId: "haberdasher-labs_allowlist-eligibility",
+        moduleVersion: "v0.1.0",
         hatId: hat1_1_1,
         immutableArgs: [hat1, hat1_1],
         mutableArgs: [[]],
@@ -143,13 +144,15 @@ describe("Write Functions Client Tests", () => {
 
     test("Test addAccount", async () => {
       const module = hatsModulesClient.getModuleById(
-        "0xaC208e6668DE569C6ea1db76DeCea70430335Ed5"
+        "haberdasher-labs_allowlist-eligibility",
+        "v0.1.0"
       ) as Module;
 
       await expect(async () => {
         await hatsModulesClient.callInstanceWriteFunction({
           account: account2,
-          moduleId: "0xaC208e6668DE569C6ea1db76DeCea70430335Ed5",
+          moduleId: "haberdasher-labs_allowlist-eligibility",
+          moduleVersion: "v0.1.0",
           instance: allowListInstance,
           func: module?.writeFunctions[0],
           args: [account2.address],
@@ -161,7 +164,8 @@ describe("Write Functions Client Tests", () => {
       await expect(async () => {
         await hatsModulesClient.callInstanceWriteFunction({
           account: account2,
-          moduleId: "0xaC208e6668DE569C6ea1db76DeCea70430335Ed5",
+          moduleId: "haberdasher-labs_allowlist-eligibility",
+          moduleVersion: "v0.1.0",
           instance: allowListInstance,
           func: module?.writeFunctions[0],
           args: [1],
@@ -172,7 +176,8 @@ describe("Write Functions Client Tests", () => {
 
       const res = await hatsModulesClient.callInstanceWriteFunction({
         account: account1,
-        moduleId: "0xaC208e6668DE569C6ea1db76DeCea70430335Ed5",
+        moduleId: "haberdasher-labs_allowlist-eligibility",
+        moduleVersion: "v0.1.0",
         instance: allowListInstance,
         func: module?.writeFunctions[0],
         args: [account2.address],
@@ -191,12 +196,14 @@ describe("Write Functions Client Tests", () => {
 
     test("Test removeAccount", async () => {
       const module = hatsModulesClient.getModuleById(
-        "0xaC208e6668DE569C6ea1db76DeCea70430335Ed5"
+        "haberdasher-labs_allowlist-eligibility",
+        "v0.1.0"
       ) as Module;
 
       const res = await hatsModulesClient.callInstanceWriteFunction({
         account: account1,
-        moduleId: "0xaC208e6668DE569C6ea1db76DeCea70430335Ed5",
+        moduleId: "haberdasher-labs_allowlist-eligibility",
+        moduleVersion: "v0.1.0",
         instance: allowListInstance,
         func: module?.writeFunctions[2],
         args: [account2.address],
@@ -215,12 +222,14 @@ describe("Write Functions Client Tests", () => {
 
     test("Test addAccounts", async () => {
       const module = hatsModulesClient.getModuleById(
-        "0xaC208e6668DE569C6ea1db76DeCea70430335Ed5"
+        "haberdasher-labs_allowlist-eligibility",
+        "v0.1.0"
       ) as Module;
 
       const res = await hatsModulesClient.callInstanceWriteFunction({
         account: account1,
-        moduleId: "0xaC208e6668DE569C6ea1db76DeCea70430335Ed5",
+        moduleId: "haberdasher-labs_allowlist-eligibility",
+        moduleVersion: "v0.1.0",
         instance: allowListInstance,
         func: module?.writeFunctions[1],
         args: [[account1.address, account2.address]],
@@ -246,12 +255,14 @@ describe("Write Functions Client Tests", () => {
 
     test("Test removeAccounts", async () => {
       const module = hatsModulesClient.getModuleById(
-        "0xaC208e6668DE569C6ea1db76DeCea70430335Ed5"
+        "haberdasher-labs_allowlist-eligibility",
+        "v0.1.0"
       ) as Module;
 
       const res = await hatsModulesClient.callInstanceWriteFunction({
         account: account1,
-        moduleId: "0xaC208e6668DE569C6ea1db76DeCea70430335Ed5",
+        moduleId: "haberdasher-labs_allowlist-eligibility",
+        moduleVersion: "v0.1.0",
         instance: allowListInstance,
         func: module?.writeFunctions[4],
         args: [[account1.address, account2.address]],
@@ -277,13 +288,15 @@ describe("Write Functions Client Tests", () => {
 
     test("Test setStandingForAccount", async () => {
       const module = hatsModulesClient.getModuleById(
-        "0xaC208e6668DE569C6ea1db76DeCea70430335Ed5"
+        "haberdasher-labs_allowlist-eligibility",
+        "v0.1.0"
       ) as Module;
 
       await expect(async () => {
         await hatsModulesClient.callInstanceWriteFunction({
           account: account1,
-          moduleId: "0xaC208e6668DE569C6ea1db76DeCea70430335Ed5",
+          moduleId: "haberdasher-labs_allowlist-eligibility",
+          moduleVersion: "v0.1.0",
           instance: allowListInstance,
           func: module?.writeFunctions[5],
           args: [account2.address, false],
@@ -294,7 +307,8 @@ describe("Write Functions Client Tests", () => {
 
       const res = await hatsModulesClient.callInstanceWriteFunction({
         account: account2,
-        moduleId: "0xaC208e6668DE569C6ea1db76DeCea70430335Ed5",
+        moduleId: "haberdasher-labs_allowlist-eligibility",
+        moduleVersion: "v0.1.0",
         instance: allowListInstance,
         func: module?.writeFunctions[5],
         args: [account2.address, false],
@@ -313,13 +327,15 @@ describe("Write Functions Client Tests", () => {
 
     test("Test removeAccountAndBurnHat", async () => {
       const module = hatsModulesClient.getModuleById(
-        "0xaC208e6668DE569C6ea1db76DeCea70430335Ed5"
+        "haberdasher-labs_allowlist-eligibility",
+        "v0.1.0"
       ) as Module;
 
       await expect(async () => {
         await hatsModulesClient.callInstanceWriteFunction({
           account: account1,
-          moduleId: "0xaC208e6668DE569C6ea1db76DeCea70430335Ed5",
+          moduleId: "haberdasher-labs_allowlist-eligibility",
+          moduleVersion: "v0.1.0",
           instance: allowListInstance,
           func: module?.writeFunctions[3],
           args: [account2.address],
@@ -331,13 +347,15 @@ describe("Write Functions Client Tests", () => {
 
     test("Test setStandingForAccounts", async () => {
       const module = hatsModulesClient.getModuleById(
-        "0xaC208e6668DE569C6ea1db76DeCea70430335Ed5"
+        "haberdasher-labs_allowlist-eligibility",
+        "v0.1.0"
       ) as Module;
 
       await expect(async () => {
         await hatsModulesClient.callInstanceWriteFunction({
           account: account2,
-          moduleId: "0xaC208e6668DE569C6ea1db76DeCea70430335Ed5",
+          moduleId: "haberdasher-labs_allowlist-eligibility",
+          moduleVersion: "v0.1.0",
           instance: allowListInstance,
           func: module?.writeFunctions[7],
           args: [[account2.address], [true, false]],
@@ -357,7 +375,8 @@ describe("Write Functions Client Tests", () => {
       const hatElectionsInstanceRes = await hatsModulesClient.createNewInstance(
         {
           account: account1,
-          moduleId: "0xd3b916a8F0C4f9D1d5B6Af29c3C012dbd4f3149E",
+          moduleId: "haberdasher-labs_hats-election-eligibility",
+          moduleVersion: "v0.2.0",
           hatId: hat1_1_1,
           immutableArgs: [hat1_1, hat1_2],
           mutableArgs: [electionsEndTime],
@@ -374,13 +393,15 @@ describe("Write Functions Client Tests", () => {
 
     test("Test elect", async () => {
       const module = hatsModulesClient.getModuleById(
-        "0xd3b916a8F0C4f9D1d5B6Af29c3C012dbd4f3149E"
+        "haberdasher-labs_hats-election-eligibility",
+        "v0.2.0"
       ) as Module;
 
       await expect(async () => {
         await hatsModulesClient.callInstanceWriteFunction({
           account: account1,
-          moduleId: "0xd3b916a8F0C4f9D1d5B6Af29c3C012dbd4f3149E",
+          moduleId: "haberdasher-labs_hats-election-eligibility",
+          moduleVersion: "v0.2.0",
           instance: hatElectionsInstance,
           func: module?.writeFunctions[1],
           args: [electionsEndTime, [account1.address]],
@@ -391,7 +412,8 @@ describe("Write Functions Client Tests", () => {
 
       const res = await hatsModulesClient.callInstanceWriteFunction({
         account: account2,
-        moduleId: "0xd3b916a8F0C4f9D1d5B6Af29c3C012dbd4f3149E",
+        moduleId: "haberdasher-labs_hats-election-eligibility",
+        moduleVersion: "v0.2.0",
         instance: hatElectionsInstance,
         func: module?.writeFunctions[1],
         args: [electionsEndTime, [account1.address]],
@@ -419,7 +441,8 @@ describe("Write Functions Client Tests", () => {
 
       const jokeraceInstanceRes = await hatsModulesClient.createNewInstance({
         account: account1,
-        moduleId: "0xAE0e56A0c509dA713722c1aFFcF4B5f1C6CDc73a",
+        moduleId: "haberdasher-labs_jokerace-eligibility",
+        moduleVersion: "v0.2.0",
         hatId: hat1_1_1,
         immutableArgs: [hat1_1],
         mutableArgs: [
@@ -439,13 +462,15 @@ describe("Write Functions Client Tests", () => {
 
     test("Test pullElectionResults and reelection", async () => {
       const module = hatsModulesClient.getModuleById(
-        "0xAE0e56A0c509dA713722c1aFFcF4B5f1C6CDc73a"
+        "haberdasher-labs_jokerace-eligibility",
+        "v0.2.0"
       ) as Module;
 
       await expect(async () => {
         await hatsModulesClient.callInstanceWriteFunction({
           account: account1,
-          moduleId: "0xAE0e56A0c509dA713722c1aFFcF4B5f1C6CDc73a",
+          moduleId: "haberdasher-labs_jokerace-eligibility",
+          moduleVersion: "v0.2.0",
           instance: jokeraceInstance,
           func: module?.writeFunctions[1],
           args: [
@@ -460,7 +485,8 @@ describe("Write Functions Client Tests", () => {
 
       const res = await hatsModulesClient.callInstanceWriteFunction({
         account: account2,
-        moduleId: "0xAE0e56A0c509dA713722c1aFFcF4B5f1C6CDc73a",
+        moduleId: "haberdasher-labs_jokerace-eligibility",
+        moduleVersion: "v0.2.0",
         instance: jokeraceInstance,
         func: module?.writeFunctions[0],
         args: [],
@@ -476,7 +502,8 @@ describe("Write Functions Client Tests", () => {
     beforeAll(async () => {
       const passthroughInstanceRes = await hatsModulesClient.createNewInstance({
         account: account1,
-        moduleId: "0x050079a8fbFCE76818C62481BA015b89567D2d35",
+        moduleId: "haberdasher-labs_passthrough-module",
+        moduleVersion: "v0.1.0",
         hatId: hat1_1_1,
         immutableArgs: [hat1_1],
         mutableArgs: [],
@@ -492,13 +519,15 @@ describe("Write Functions Client Tests", () => {
 
     test("Test setHatWearerStatus", async () => {
       const module = hatsModulesClient.getModuleById(
-        "0x050079a8fbFCE76818C62481BA015b89567D2d35"
+        "haberdasher-labs_passthrough-module",
+        "v0.1.0"
       ) as Module;
 
       await expect(async () => {
         await hatsModulesClient.callInstanceWriteFunction({
           account: account1,
-          moduleId: "0x050079a8fbFCE76818C62481BA015b89567D2d35",
+          moduleId: "haberdasher-labs_passthrough-module",
+          moduleVersion: "v0.1.0",
           instance: passthroughInstance,
           func: module?.writeFunctions[0],
           args: [hat1_1_1, account2.address, false, false],
@@ -509,7 +538,8 @@ describe("Write Functions Client Tests", () => {
 
       const res = await hatsModulesClient.callInstanceWriteFunction({
         account: account2,
-        moduleId: "0x050079a8fbFCE76818C62481BA015b89567D2d35",
+        moduleId: "haberdasher-labs_passthrough-module",
+        moduleVersion: "v0.1.0",
         instance: passthroughInstance,
         func: module?.writeFunctions[0],
         args: [hat1_1_1, account2.address, false, false],
@@ -525,7 +555,8 @@ describe("Write Functions Client Tests", () => {
     beforeAll(async () => {
       const seasonInstanceRes = await hatsModulesClient.createNewInstance({
         account: account1,
-        moduleId: "0xFb6bD2e96B123d0854064823f6cb59420A285C00",
+        moduleId: "haberdasher-labs_season-toggle",
+        moduleVersion: "v0.1.0",
         hatId: hat1_2,
         immutableArgs: [],
         mutableArgs: [2592000n, 5000n],
@@ -541,13 +572,15 @@ describe("Write Functions Client Tests", () => {
 
     test("Test extend", async () => {
       const module = hatsModulesClient.getModuleById(
-        "0xFb6bD2e96B123d0854064823f6cb59420A285C00"
+        "haberdasher-labs_season-toggle",
+        "v0.1.0"
       ) as Module;
 
       await expect(async () => {
         await hatsModulesClient.callInstanceWriteFunction({
           account: account2,
-          moduleId: "0xFb6bD2e96B123d0854064823f6cb59420A285C00",
+          moduleId: "haberdasher-labs_season-toggle",
+          moduleVersion: "v0.1.0",
           instance: seasonInstance,
           func: module?.writeFunctions[0],
           args: [2592000n, 5000n],
@@ -564,7 +597,8 @@ describe("Write Functions Client Tests", () => {
     beforeAll(async () => {
       const stakingInstanceRes = await hatsModulesClient.createNewInstance({
         account: account1,
-        moduleId: "0x9E01030aF633Be5a439DF122F2eEf750b44B8aC7",
+        moduleId: "haberdasher-labs_staking-eligibility",
+        moduleVersion: "v0.1.0",
         hatId: hat1_1_1,
         immutableArgs: ["0x1d256A1154382921067d4B17CA52209f2d3bE106"],
         mutableArgs: [100n, hat1_1, hat1_1, 86400n],
@@ -580,13 +614,15 @@ describe("Write Functions Client Tests", () => {
 
     test("Test slash", async () => {
       const module = hatsModulesClient.getModuleById(
-        "0x9E01030aF633Be5a439DF122F2eEf750b44B8aC7"
+        "haberdasher-labs_staking-eligibility",
+        "v0.1.0"
       ) as Module;
 
       await expect(async () => {
         await hatsModulesClient.callInstanceWriteFunction({
           account: account1,
-          moduleId: "0x9E01030aF633Be5a439DF122F2eEf750b44B8aC7",
+          moduleId: "haberdasher-labs_staking-eligibility",
+          moduleVersion: "v0.1.0",
           instance: stakingInstance,
           func: module?.writeFunctions[8],
           args: [account2.address],


### PR DESCRIPTION
Currently, the `client.getModuleById(id: string)` function actually expects the module's implementation address, which makes it kind of redundant as far as I can tell, given that there's also a `client.getModuleByImplementation(address: Address)` function.

So, this PR updates the `getModuleById(id: string)` function to accept the module's specific ID, as specified by the `id` parameter in the `modules-registry` repository's published module metadatas (for example: https://github.com/Hats-Protocol/modules-registry/blob/4212b61f818515e544f23c2abfdfe6e48d4704ce/modules/haberdasher-labs_hats-election-eligibility_v0.2.0.json#L2)

Now, since module names are not unique (it's valid and expected to have multiple versions for the same module id), I've also updated the `getModuleById(id: string)` function's arity to _also_ require a `version` string: `getModuleById(id: string, version: string)`.

Have updated all of the tests to account for these changes.